### PR TITLE
Add support for parsing Nvd version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
             <groupId>io.github.jeremylong</groupId>
             <artifactId>open-vulnerability-clients</artifactId>
             <version>${lib.open-vulnerability-clients.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
             <groupId>io.github.jeremylong</groupId>
             <artifactId>open-vulnerability-clients</artifactId>
             <version>${lib.open-vulnerability-clients.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/github/nscuro/versatile/VersUtils.java
+++ b/src/main/java/io/github/nscuro/versatile/VersUtils.java
@@ -120,9 +120,12 @@ public final class VersUtils {
     }
 
     /**
-     * Convert a cpeMatch or exact version as used by NVD to a {@link Vers} range.
+     * Convert ranges or exact version as used by NVD to a {@link Vers} range.
      *
-     * @param cpeMatch      CpeMatch object for the CVE
+     * @param versionStartExcluding   The versionStartExcluding in the range
+     * @param versionStartIncluding   The versionStartIncluding in the range
+     * @param versionEndExcluding   The versionEndExcluding in the range
+     * @param versionEndIncluding   The versionEndIncluding in the range
      * @param exactVersion  The exact version in CpeMatch
      * @return The resulting {@link Vers}
      * @throws IllegalArgumentException When the provided cpe match is invalid,

--- a/src/main/java/io/github/nscuro/versatile/VersUtils.java
+++ b/src/main/java/io/github/nscuro/versatile/VersUtils.java
@@ -18,7 +18,6 @@
  */
 package io.github.nscuro.versatile;
 
-import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
 import io.github.nscuro.versatile.version.InvalidVersionException;
 import io.github.nscuro.versatile.version.VersioningScheme;
 
@@ -131,22 +130,24 @@ public final class VersUtils {
      * @throws VersException            When the produced {@link Vers} is invalid
      * @throws InvalidVersionException  When any version in the range is invalid according to the inferred {@link VersioningScheme}
      */
-    public static Vers versFromNvdRange(final CpeMatch cpeMatch, final String exactVersion) {
+    public static Vers versFromNvdRange(final String versionStartExcluding, final String versionStartIncluding,
+                                        final String versionEndExcluding, final String versionEndIncluding,
+                                        final String exactVersion) {
 
         // Using 'generic' as versioning scheme for NVD due to lack of package data.
         final var versBuilder = Vers.builder(VersioningScheme.GENERIC);
 
-        if (trimToNull(cpeMatch.getVersionStartExcluding()) != null) {
-            versBuilder.withConstraint(Comparator.GREATER_THAN, cpeMatch.getVersionStartExcluding());
+        if (trimToNull(versionStartExcluding) != null) {
+            versBuilder.withConstraint(Comparator.GREATER_THAN, versionStartExcluding);
         }
-        if (trimToNull(cpeMatch.getVersionStartIncluding()) != null) {
-            versBuilder.withConstraint(Comparator.GREATER_THAN_OR_EQUAL, cpeMatch.getVersionStartIncluding());
+        if (trimToNull(versionStartIncluding) != null) {
+            versBuilder.withConstraint(Comparator.GREATER_THAN_OR_EQUAL, versionStartIncluding);
         }
-        if (trimToNull(cpeMatch.getVersionEndExcluding()) != null) {
-            versBuilder.withConstraint(Comparator.LESS_THAN, cpeMatch.getVersionEndExcluding());
+        if (trimToNull(versionEndExcluding) != null) {
+            versBuilder.withConstraint(Comparator.LESS_THAN, versionEndExcluding);
         }
-        if (trimToNull(cpeMatch.getVersionEndIncluding()) != null) {
-            versBuilder.withConstraint(Comparator.LESS_THAN_OR_EQUAL, cpeMatch.getVersionEndIncluding());
+        if (trimToNull(versionEndIncluding) != null) {
+            versBuilder.withConstraint(Comparator.LESS_THAN_OR_EQUAL, versionEndIncluding);
         }
         // If CpeMatch does not define a version range, but the CPE itself can
         // still give us the information we need. The version field can either be:

--- a/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
+++ b/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
@@ -30,7 +30,6 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import io.github.jeremylong.openvulnerability.client.ghsa.GitHubSecurityAdvisoryClient;
 import io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory;
 import io.github.jeremylong.openvulnerability.client.ghsa.Vulnerabilities;
-import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
 import io.github.nscuro.versatile.version.VersioningScheme;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -288,23 +287,19 @@ class VersUtilsTest {
     private static Stream<Arguments> testVersFromNvdRangeArguments() {
         return Stream.of(
                 arguments(
-                        new CpeMatch(true, "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", null, null, "2.2.0", null, "2.2.13"),
-                        "*",
+                        null, "2.2.0", null, "2.2.13", "*",
                         "vers:generic/>=2.2.0|<=2.2.13"
                 ),
                 arguments(
-                        new CpeMatch(true, "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*", null, null, null, null, null),
-                        "6.0.7",
+                        null, null, null, null, "6.0.7",
                         "vers:generic/6.0.7"
                 ),
                 arguments(
-                        new CpeMatch(true, "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*", null, null, null, null, null),
-                        "*",
+                        null, null, null, null, "*",
                         "vers:generic/*"
                 ),
                 arguments(
-                        new CpeMatch(true, "cpe:2.3:o:linux:linux_kernel:6.0.7:*:*:*:*:*:*:*:*", null, null, "2.2.0", null, null),
-                        "6.0.7",
+                        null, "2.2.0", null, null, "6.0.7",
                         "vers:generic/>=2.2.0"
                 )
         );
@@ -312,7 +307,10 @@ class VersUtilsTest {
 
     @ParameterizedTest
     @MethodSource("testVersFromNvdRangeArguments")
-    void testVersFromNvdRange(final CpeMatch cpeMatch, final String exactVersion, final String expectedVers) {
-        assertThat(versFromNvdRange(cpeMatch, exactVersion)).hasToString(expectedVers);
+    void testVersFromNvdRange(final String versionStartExcluding, final String versionStartIncluding,
+                              final String versionEndExcluding, final String versionEndIncluding,
+                              final String exactVersion, final String expectedVers) {
+        assertThat(versFromNvdRange(versionStartExcluding, versionStartIncluding, versionEndExcluding, versionEndIncluding, exactVersion))
+                .hasToString(expectedVers);
     }
 }

--- a/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
+++ b/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
@@ -30,6 +30,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import io.github.jeremylong.openvulnerability.client.ghsa.GitHubSecurityAdvisoryClient;
 import io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory;
 import io.github.jeremylong.openvulnerability.client.ghsa.Vulnerabilities;
+import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
 import io.github.nscuro.versatile.version.VersioningScheme;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ import static io.github.jeremylong.openvulnerability.client.ghsa.GitHubSecurityA
 import static io.github.nscuro.versatile.VersUtils.schemeFromGhsaEcosystem;
 import static io.github.nscuro.versatile.VersUtils.schemeFromOsvEcosystem;
 import static io.github.nscuro.versatile.VersUtils.versFromGhsaRange;
+import static io.github.nscuro.versatile.VersUtils.versFromNvdRange;
 import static io.github.nscuro.versatile.VersUtils.versFromOsvRange;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -283,4 +285,34 @@ class VersUtilsTest {
         }
     }
 
+    private static Stream<Arguments> testVersFromNvdRangeArguments() {
+        return Stream.of(
+                arguments(
+                        new CpeMatch(true, "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", null, null, "2.2.0", null, "2.2.13"),
+                        "*",
+                        "vers:generic/>=2.2.0|<=2.2.13"
+                ),
+                arguments(
+                        new CpeMatch(true, "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*", null, null, null, null, null),
+                        "6.0.7",
+                        "vers:generic/6.0.7"
+                ),
+                arguments(
+                        new CpeMatch(true, "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*", null, null, null, null, null),
+                        "*",
+                        "vers:generic/*"
+                ),
+                arguments(
+                        new CpeMatch(true, "cpe:2.3:o:linux:linux_kernel:6.0.7:*:*:*:*:*:*:*:*", null, null, "2.2.0", null, null),
+                        "6.0.7",
+                        "vers:generic/>=2.2.0"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testVersFromNvdRangeArguments")
+    void testVersFromNvdRange(final CpeMatch cpeMatch, final String exactVersion, final String expectedVers) {
+        assertThat(versFromNvdRange(cpeMatch, exactVersion)).hasToString(expectedVers);
+    }
 }


### PR DESCRIPTION
Building of vers range in versatile library is missing for NVD. 
Added the same.

Closes https://github.com/DependencyTrack/hyades/issues/1108