### PR TITLE
Fix revision not being considered optional in `DebianVersion`

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/DebianVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/DebianVersion.java
@@ -54,7 +54,7 @@ public class DebianVersion extends Version {
 
         this.epoch = Optional.ofNullable(versionMatcher.group("epoch")).map(Integer::parseInt).orElse(0);
         this.upstreamVersion = versionMatcher.group("upstreamVersion");
-        this.debianRevision = versionMatcher.group("debianRevision");
+        this.debianRevision = Optional.ofNullable(versionMatcher.group("debianRevision")).orElse("0");
 
         if (this.upstreamVersion == null) {
             throw new InvalidVersionException(versionStr, """

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/version/DebianVersionTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/version/DebianVersionTest.java
@@ -26,6 +26,7 @@ class DebianVersionTest extends AbstractVersionTest {
     @ParameterizedTest
     @CsvSource(value = {
             "0, IS_LOWER_THAN, 1",
+            "1, IS_EQUAL_TO, 1",
             "114.0.5735.106-1~deb11u1, IS_LOWER_THAN, 114.0.5735.133-1~deb12u1",
             "114.0.5735.133-1, IS_HIGHER_THAN, 114.0.5735.133-1~deb12u1"
     })


### PR DESCRIPTION
This could lead to NPEs during comparison due to `debianRevision` being `null`