### PR TITLE
Fix release not being considered optional in `RpmVersion`

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/RpmVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/RpmVersion.java
@@ -63,7 +63,7 @@ public class RpmVersion extends Version {
 
         this.epoch = Optional.ofNullable(versionMatcher.group("epoch")).map(Integer::parseInt).orElse(0);
         this.version = versionMatcher.group("version");
-        this.release = versionMatcher.group("release");
+        this.release = Optional.ofNullable(versionMatcher.group("release")).orElse("0");
 
         if (this.version == null) {
             throw new InvalidVersionException(versionStr, """

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/version/RpmVersionTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/version/RpmVersionTest.java
@@ -144,6 +144,9 @@ class RpmVersionTest extends AbstractVersionTest {
             "1.1.αα, IS_EQUAL_TO, 1.1.α",
             "1.1.α, IS_EQUAL_TO, 1.1.ββ",
             "1.1.ββ, IS_EQUAL_TO, 1.1.αα",
+            // Custom test cases
+            "1.0-1, IS_HIGHER_THAN, 1.0",
+            "1.0, IS_LOWER_THAN, 1.0-1"
     })
     void testCompareTo(final String versionA, final ComparisonExpectation expectation, final String versionB) {
         expectation.evaluate(new RpmVersion(versionA), new RpmVersion(versionB));


### PR DESCRIPTION
This could lead to NPEs during comparison due to `release` being `null`