### PR TITLE
Fix `ComponentVersion` repeatedly recompiling the same regex pattern

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/ext/ComponentVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/ext/ComponentVersion.java
@@ -42,6 +42,12 @@ import java.util.regex.Pattern;
  */
 public class ComponentVersion implements Iterable<String>, Comparable<ComponentVersion> {
 
+    private static final Pattern DEBIAN_VERSION_PATTERN = Pattern.compile(
+            "^([0-9]+:)?(.*)(-[^-]+ubuntu[^-]+)$");
+    private static final Pattern VERSION_PATTERN = Pattern.compile(
+            "(\\d+[a-z]{1,3}$|[a-z]{1,3}[_-]?\\d+|\\d+|(rc|release|snapshot|beta|alpha)$)",
+            Pattern.CASE_INSENSITIVE);
+
     /**
      * A list of the version parts.
      */
@@ -78,15 +84,12 @@ public class ComponentVersion implements Iterable<String>, Comparable<ComponentV
             // https://github.com/DependencyTrack/dependency-track/issues/1374
             // handle deb versions
             String lcVersion = version.toLowerCase();
-            final Pattern debrx = Pattern.compile("^([0-9]+:)?(.*)(-[^-]+ubuntu[^-]+)$");
-            final Matcher debmatcher = debrx.matcher(lcVersion);
+            final Matcher debmatcher = DEBIAN_VERSION_PATTERN.matcher(lcVersion);
             if (debmatcher.matches()) {
                 lcVersion = debmatcher.group(2);
             }
 
-            final Pattern rx = Pattern.compile("(\\d+[a-z]{1,3}$|[a-z]{1,3}[_-]?\\d+|\\d+|(rc|release|snapshot|beta|alpha)$)",
-                    Pattern.CASE_INSENSITIVE);
-            final Matcher matcher = rx.matcher(lcVersion);
+            final Matcher matcher = VERSION_PATTERN.matcher(lcVersion);
             while (matcher.find()) {
                 versionParts.add(matcher.group());
             }


### PR DESCRIPTION
This caused excesses CPU cycles and memory allocations.