### PR TITLE
Improve Debian and RPM version comparison performance

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/DebianVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/DebianVersion.java
@@ -55,6 +55,8 @@ public class DebianVersion extends Version {
     private final int epoch;
     private final String upstreamVersion;
     private final String debianRevision;
+    private final String[] upstreamVersionSegments;
+    private final String[] debianRevisionSegments;
 
     DebianVersion(final String versionStr) {
         super(SCHEME_DEBIAN, versionStr);
@@ -77,6 +79,9 @@ public class DebianVersion extends Version {
                     according to the Debian version format [epoch:]upstream-version[-debian-revision]\
                     """.formatted(versionStr));
         }
+
+        this.upstreamVersionSegments = splitSegments(this.upstreamVersion);
+        this.debianRevisionSegments = splitSegments(this.debianRevision);
     }
 
     /**
@@ -93,19 +98,23 @@ public class DebianVersion extends Version {
      * {@inheritDoc}
      */
     @Override
-    public int compareTo(final Version other) {
+    public int compareTo(Version other) {
         if (other instanceof final DebianVersion otherVersion) {
             int comparisonResult = Integer.compare(this.epoch, otherVersion.epoch);
             if (comparisonResult != 0) {
                 return comparisonResult;
             }
 
-            comparisonResult = compareVersionPart(this.upstreamVersion, otherVersion.upstreamVersion);
+            comparisonResult = compareVersionPart(
+                    this.upstreamVersionSegments,
+                    otherVersion.upstreamVersionSegments);
             if (comparisonResult != 0) {
                 return comparisonResult;
             }
 
-            return compareVersionPart(this.debianRevision, otherVersion.debianRevision);
+            return compareVersionPart(
+                    this.debianRevisionSegments,
+                    otherVersion.debianRevisionSegments);
         }
 
         throw new IllegalArgumentException("%s can only be compared with its own type, but got %s"
@@ -124,44 +133,32 @@ public class DebianVersion extends Version {
         return debianRevision;
     }
 
-    private static int compareVersionPart(final String versionPartA, final String versionPartB) {
-        final var listA = new ArrayList<String>();
-        final var listB = new ArrayList<String>();
-
-        final Matcher matcherA = DIGIT_OR_NON_DIGIT_PATTERN.matcher(versionPartA);
-        while (matcherA.find()) {
-            listA.add(matcherA.group());
+    private static String[] splitSegments(String versionPart) {
+        final var segments = new ArrayList<String>();
+        final Matcher matcher = DIGIT_OR_NON_DIGIT_PATTERN.matcher(versionPart);
+        while (matcher.find()) {
+            segments.add(matcher.group());
         }
 
-        final Matcher matcherB = DIGIT_OR_NON_DIGIT_PATTERN.matcher(versionPartB);
-        while (matcherB.find()) {
-            listB.add(matcherB.group());
-        }
+        return segments.toArray(new String[0]);
+    }
 
-        while (!listA.isEmpty() || !listB.isEmpty()) {
-            var a = "0";
-            var b = "0";
+    private static int compareVersionPart(String[] segmentsA, String[] segmentsB) {
+        final int max = Math.max(segmentsA.length, segmentsB.length);
 
-            if (!listA.isEmpty()) {
-                a = listA.remove(0);
-            }
-            if (!listB.isEmpty()) {
-                b = listB.remove(0);
-            }
+        for (int i = 0; i < max; i++) {
+            final String a = i < segmentsA.length ? segmentsA[i] : "0";
+            final String b = i < segmentsB.length ? segmentsB[i] : "0";
 
+            final int comparisonResult;
             if (isNumeric(a) && isNumeric(b)) {
-                int intA = Integer.parseInt(a);
-                int intB = Integer.parseInt(b);
-                int comparisonResult = Integer.compare(intA, intB);
-
-                if (comparisonResult != 0) {
-                    return comparisonResult;
-                }
+                comparisonResult = Integer.compare(Integer.parseInt(a), Integer.parseInt(b));
             } else {
-                int comparisonResult = compareString(a, b);
-                if (comparisonResult != 0) {
-                    return comparisonResult;
-                }
+                comparisonResult = compareString(a, b);
+            }
+
+            if (comparisonResult != 0) {
+                return comparisonResult;
             }
         }
 
@@ -169,28 +166,17 @@ public class DebianVersion extends Version {
     }
 
     private static int compareString(final String versionPartA, final String versionPartB) {
-        final var listA = new ArrayList<Integer>();
-        final var listB = new ArrayList<Integer>();
+        final int max = Math.max(versionPartA.length(), versionPartB.length());
 
-        for (char charA : versionPartA.toCharArray()) {
-            listA.add(charOrder(charA));
-        }
-        for (char charB : versionPartB.toCharArray()) {
-            listB.add(charOrder(charB));
-        }
+        for (int i = 0; i < max; i++) {
+            final int a = i < versionPartA.length()
+                    ? charOrder(versionPartA.charAt(i))
+                    : 0;
+            final int b = i < versionPartB.length()
+                    ? charOrder(versionPartB.charAt(i))
+                    : 0;
 
-        while (!listA.isEmpty() || !listB.isEmpty()) {
-            int a = 0;
-            int b = 0;
-
-            if (!listA.isEmpty()) {
-                a = listA.remove(0);
-            }
-            if (!listB.isEmpty()) {
-                b = listB.remove(0);
-            }
-
-            int comparisonResult = Integer.compare(a, b);
+            final int comparisonResult = Integer.compare(a, b);
             if (comparisonResult != 0) {
                 return comparisonResult;
             }

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/PythonVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/PythonVersion.java
@@ -29,6 +29,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_PYPI;
+import static io.github.nscuro.versatile.version.VersionUtils.isNumeric;
 
 /**
  * @see <a href="https://peps.python.org/pep-0440/">PEP 440 – Version Identification and Dependency Specification</a>
@@ -81,7 +82,6 @@ public class PythonVersion extends Version {
     private static final Pattern NORM_PATTERN_LOCAL_SEP = Pattern.compile("\\+([a-zA-Z0-9]+)[-_.]");
     private static final Pattern LOCAL_SEGMENT_SEPARATOR_PATTERN = Pattern.compile("\\.");
     private static final Pattern LOCAL_NORMALIZE_PATTERN = Pattern.compile("[-_]");
-    private static final Pattern ASCII_DIGITS_PATTERN = Pattern.compile("\\d+");
 
     private final int epoch;
     private final List<Integer> release;
@@ -434,7 +434,7 @@ public class PythonVersion extends Version {
             final String p2 = i < parts2.length ? parts2[i] : "";
 
             final int result;
-            if (ASCII_DIGITS_PATTERN.matcher(p1).matches() && ASCII_DIGITS_PATTERN.matcher(p2).matches()) {
+            if (isNumeric(p1) && isNumeric(p2)) {
                 result = Integer.compare(Integer.parseInt(p1), Integer.parseInt(p2));
             } else {
                 result = p1.compareTo(p2);

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/RpmVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/RpmVersion.java
@@ -58,6 +58,8 @@ public class RpmVersion extends Version {
     private final int epoch;
     private final String version;
     private final String release;
+    private final String[] versionSegments;
+    private final String[] releaseSegments;
 
     /**
      * Create a new {@link RpmVersion}.
@@ -86,6 +88,9 @@ public class RpmVersion extends Version {
                     according to the RPM version format [epoch:]version[-release]\
                     """.formatted(versionStr));
         }
+
+        this.versionSegments = splitSegments(this.version);
+        this.releaseSegments = splitSegments(this.release);
     }
 
     /**
@@ -113,16 +118,21 @@ public class RpmVersion extends Version {
                 return comparisonResult;
             }
 
-            comparisonResult = rpmVerCmp(this.version, otherVersion.version);
+            comparisonResult = !this.version.equals(otherVersion.version)
+                    ? rpmVerCmp(this.versionSegments, otherVersion.versionSegments)
+                    : 0;
             if (comparisonResult != 0) {
                 return comparisonResult;
             }
 
-            return rpmVerCmp(this.release, otherVersion.release);
+            return !this.release.equals(otherVersion.release)
+                    ? rpmVerCmp(this.releaseSegments, otherVersion.releaseSegments)
+                    : 0;
         }
 
-        throw new IllegalArgumentException("%s can only be compared with its own type, but got %s"
-                .formatted(this.getClass().getName(), other.getClass().getName()));
+        throw new IllegalArgumentException(
+                "%s can only be compared with its own type, but got %s".formatted(
+                        this.getClass().getName(), other.getClass().getName()));
     }
 
     public int epoch() {
@@ -137,33 +147,21 @@ public class RpmVersion extends Version {
         return release;
     }
 
-    private static int rpmVerCmp(final String a, final String b) {
-        // Easy comparison to see if versions are identical.
-        if (Objects.equals(a, b)) {
-            return 0;
+    private static String[] splitSegments(String value) {
+        final var segments = new ArrayList<String>();
+        final Matcher matcher = VERSION_SEGMENT_PATTERN.matcher(value);
+        while (matcher.find()) {
+            segments.add(matcher.group());
         }
 
-        final var segmentsA = new ArrayList<String>();
-        final var segmentsB = new ArrayList<String>();
-        final Matcher matcherA = VERSION_SEGMENT_PATTERN.matcher(a);
-        while (matcherA.find()) {
-            segmentsA.add(matcherA.group());
-        }
-        final Matcher matcherB = VERSION_SEGMENT_PATTERN.matcher(b);
-        while (matcherB.find()) {
-            segmentsB.add(matcherB.group());
-        }
+        return segments.toArray(new String[0]);
+    }
 
+    private static int rpmVerCmp(String[] segmentsA, String[] segmentsB) {
         // Loop through each version segment of a and b, and compare them.
-        for (int i = 0; i < Math.max(segmentsA.size(), segmentsB.size()); i++) {
-            var segmentA = "";
-            if (segmentsA.size() >= (i + 1)) {
-                segmentA = segmentsA.get(i);
-            }
-            var segmentB = "";
-            if (segmentsB.size() >= (i + 1)) {
-                segmentB = segmentsB.get(i);
-            }
+        for (int i = 0; i < Math.max(segmentsA.length, segmentsB.length); i++) {
+            String segmentA = i < segmentsA.length ? segmentsA[i] : "";
+            String segmentB = i < segmentsB.length ? segmentsB[i] : "";
 
             // Handle the tilde separator, it sorts before everything else.
             if (segmentA.equals("~") || segmentB.equals("~")) {
@@ -206,32 +204,59 @@ public class RpmVersion extends Version {
                     return 1;
                 }
 
-                // Throw away any leading zeroes - it's a number, right?
-                segmentA = segmentA.replaceFirst("^0*", "");
-                segmentB = segmentB.replaceFirst("^0*", "");
-
-                // Whichever number has more digits wins.
-                if (segmentA.length() > segmentB.length()) {
-                    return 1;
-                } else if (segmentB.length() > segmentA.length()) {
-                    return -1;
+                // Compare numerically, ignoring any leading zeroes.
+                final int numComparisonResult = compareNumericSegments(segmentA, segmentB);
+                if (numComparisonResult != 0) {
+                    return numComparisonResult;
                 }
             } else if (isNumeric(segmentB)) {
                 return -1;
-            }
-
-            // Compare both segments as strings. Don't return if they are equal
-            // because there might be more segments to compare.
-            int strComparisonResult = segmentA.compareTo(segmentB);
-            if (strComparisonResult != 0) {
-                return strComparisonResult;
+            } else {
+                // Compare both segments as strings. Don't return if they are equal
+                // because there might be more segments to compare.
+                final int strComparisonResult = segmentA.compareTo(segmentB);
+                if (strComparisonResult != 0) {
+                    return strComparisonResult;
+                }
             }
         }
 
         // This catches the case where all numeric and alpha segments have
         // compared identically but the segment separating characters were
         // different.
-        return Integer.compare(segmentsA.size(), segmentsB.size());
+        return Integer.compare(segmentsA.length, segmentsB.length);
+    }
+
+    private static int compareNumericSegments(final String a, final String b) {
+        // Indices of the first non-zero digit (i.e. position after leading zeroes).
+        final int startA = leadingZeroEnd(a);
+        final int startB = leadingZeroEnd(b);
+        final int lenA = a.length() - startA;
+        final int lenB = b.length() - startB;
+
+        // Whichever number has more significant digits wins.
+        if (lenA != lenB) {
+            return lenA > lenB ? 1 : -1;
+        }
+
+        for (int i = 0; i < lenA; i++) {
+            final char ca = a.charAt(startA + i);
+            final char cb = b.charAt(startB + i);
+            if (ca != cb) {
+                return ca < cb ? -1 : 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int leadingZeroEnd(String segment) {
+        int i = 0;
+        while (i < segment.length() && segment.charAt(i) == '0') {
+            i++;
+        }
+
+        return i;
     }
 
 }

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/VersionUtils.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/VersionUtils.java
@@ -18,33 +18,46 @@
  */
 package io.github.nscuro.versatile.version;
 
-import java.util.regex.Pattern;
-
 /**
  * @since 0.9.0
  */
 final class VersionUtils {
 
-    private static final Pattern PATTERN_ALPHANUMERIC = Pattern.compile("^[a-zA-Z0-9\\-]+$");
-    private static final Pattern PATTERN_NUMERIC = Pattern.compile("^\\d+$");
-
     private VersionUtils() {
     }
 
-    static boolean isAlphaNumeric(final String str) {
-        if (str == null) {
+    static boolean isAlphaNumeric(String str) {
+        if (str == null || str.isEmpty()) {
             return false;
         }
 
-        return PATTERN_ALPHANUMERIC.matcher(str).matches();
+        for (int i = 0; i < str.length(); i++) {
+            final char c = str.charAt(i);
+            final boolean isAllowed = (c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-';
+            if (!isAllowed) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    static boolean isNumeric(final String str) {
-        if (str == null) {
+    static boolean isNumeric(String str) {
+        if (str == null || str.isEmpty()) {
             return false;
         }
 
-        return PATTERN_NUMERIC.matcher(str).matches();
+        for (int i = 0; i < str.length(); i++) {
+            final char c = str.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }


### PR DESCRIPTION
* Computes version segments eagerly after parsing so they can be reused across multiple comparisons.
* Avoids allocations entirely in the comparison logic by avoiding regex and boxing.