### PR TITLE
Make parsing of cargo versions more lenient

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
@@ -264,10 +264,12 @@ public final class VersUtils {
         }
 
         return switch (ecosystem.toLowerCase()) {
+            case "crates.io" -> Optional.of(KnownVersioningSchemes.SCHEME_CARGO);
             case "go" -> Optional.of(KnownVersioningSchemes.SCHEME_GOLANG);
             case "maven" -> Optional.of(KnownVersioningSchemes.SCHEME_MAVEN);
             case "npm" -> Optional.of(KnownVersioningSchemes.SCHEME_NPM);
             case "nuget" -> Optional.of(KnownVersioningSchemes.SCHEME_NUGET);
+            case "packagist" -> Optional.of(KnownVersioningSchemes.SCHEME_COMPOSER);
             case "pypi" -> Optional.of(KnownVersioningSchemes.SCHEME_PYPI);
             case "rubygems" -> Optional.of(KnownVersioningSchemes.SCHEME_GEM);
             default -> Optional.empty();

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/CargoVersion.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/CargoVersion.java
@@ -57,10 +57,18 @@ public class CargoVersion extends Version {
 
         final int[] cursor = {0};
         this.major = parseNumericField(versionStr, cursor);
-        expect(versionStr, cursor, '.');
-        this.minor = parseNumericField(versionStr, cursor);
-        expect(versionStr, cursor, '.');
-        this.patch = parseNumericField(versionStr, cursor);
+        if (peek(versionStr, cursor) == '.') {
+            cursor[0]++;
+            this.minor = parseNumericField(versionStr, cursor);
+        } else {
+            this.minor = 0;
+        }
+        if (peek(versionStr, cursor) == '.') {
+            cursor[0]++;
+            this.patch = parseNumericField(versionStr, cursor);
+        } else {
+            this.patch = 0;
+        }
 
         String[] pre = NO_PRERELEASE;
         if (peek(versionStr, cursor) == '-') {
@@ -210,14 +218,5 @@ public class CargoVersion extends Version {
 
     private static char peek(String versionStr, int[] cursor) {
         return cursor[0] < versionStr.length() ? versionStr.charAt(cursor[0]) : '\0';
-    }
-
-    private static void expect(String versionStr, int[] cursor, char expected) {
-        if (peek(versionStr, cursor) != expected) {
-            throw new InvalidVersionException(
-                    versionStr, "Expected '%c' at position %d".formatted(expected, cursor[0]));
-        }
-
-        cursor[0]++;
     }
 }

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
@@ -148,14 +148,14 @@ class VersUtilsTest {
                 "Mageia, rpm",
                 "Maven, maven",
                 "OSS-Fuzz, ",
-                "Packagist, ",
+                "Packagist, composer",
                 "Photon OS, rpm",
                 "Pub, ",
                 "PyPI, pypi",
                 "Rocky Linux, rpm",
                 "RubyGems, gem",
                 "SwiftURL, ",
-                "crates.io, ",
+                "crates.io, cargo",
                 "npm, npm",
             })
     void testSchemeFromOsvEcosystem(final String ecosystem, final String expectedScheme) {

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/version/CargoVersionTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/version/CargoVersionTest.java
@@ -50,7 +50,11 @@ class CargoVersionTest extends AbstractVersionTest {
                 "1.2.3, IS_EQUAL_TO, 1.2.3",
                 "1.2.3+23, IS_EQUAL_TO, 1.2.3+42",
                 "1.2.3, IS_EQUAL_TO, 1.2.3+build",
-                "1.2.3-alpha+1, IS_EQUAL_TO, 1.2.3-alpha+2"
+                "1.2.3-alpha+1, IS_EQUAL_TO, 1.2.3-alpha+2",
+                "0, IS_EQUAL_TO, 0.0.0",
+                "0.16, IS_EQUAL_TO, 0.16.0",
+                "1, IS_LOWER_THAN, 1.0.1",
+                "0, IS_LOWER_THAN, 0.3.24"
             })
     void testCompareTo(String versionA, ComparisonExpectation expectation, String versionB) {
         expectation.evaluate(new CargoVersion(versionA), new CargoVersion(versionB));
@@ -65,8 +69,6 @@ class CargoVersionTest extends AbstractVersionTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "1",
-                "1.2",
                 "1.2.3-",
                 "a.b.c",
                 "1.2.3-01",


### PR DESCRIPTION
The parser expected strict `major.minor.patch` format, but data sources like OSV may provide versions as `major` or `major.minor`. Make the parser more lenient to accept such partial versions.