### PR TITLE
Enable roundtrip conformance tests

### DIFF
--- a/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
+++ b/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
@@ -103,6 +103,7 @@ class VersConformanceTest {
             case COMPARISON -> testComparison(versTest);
             case CONTAINMENT -> testContainment(versTest);
             case EQUALITY -> testEquality(versTest);
+            case ROUNDTRIP -> testRoundtrip(versTest);
             default -> Assumptions.assumeTrue(false, "Test type not supported yet");
         }
     }
@@ -195,5 +196,22 @@ class VersConformanceTest {
         } else {
             assertThat(versionA).as(versTest.getDescription()).isNotEqualTo(versionB);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    void testRoundtrip(final VersTest versTest) {
+        assertThat(versTest.getAdditionalProperties()).isNotNull();
+
+        final var inputObject =
+                (Map<String, Object>) versTest.getAdditionalProperties().get("input");
+        assertThat(inputObject).isNotNull();
+
+        final var versStr = (String) inputObject.get("vers");
+        assertThat(versStr).isNotNull();
+
+        final var expectedOutput = (String) versTest.getAdditionalProperties().get("expected_output");
+        assertThat(expectedOutput).isNotNull();
+
+        assertThat(Vers.parse(versStr).toString()).as(versTest.getDescription()).isEqualTo(expectedOutput);
     }
 }

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
@@ -80,8 +80,10 @@ public record Vers(String scheme, List<Constraint> constraints) {
             throw new VersException("vers string contains no constraints");
         }
 
-        final List<Constraint> constraints =
-                Arrays.stream(parts).map(part -> Constraint.parse(scheme, part)).toList();
+        final List<Constraint> constraints = Arrays.stream(parts)
+                .map(part -> Constraint.parse(scheme, part))
+                .sorted()
+                .toList();
 
         return new Vers(scheme, constraints);
     }

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
@@ -100,12 +100,8 @@ class VersTest {
                         "vers:generic/1.2.3|>=2.0.0|<5.0.0",
                         List.of("vers:generic/1.2.3", "vers:generic/>=2.0.0|<5.0.0")),
                 arguments(
-                        "vers:maven/<0.5.1|>=1.2.3|!=3.2.1|<6.6.6|*",
-                        List.of(
-                                "vers:maven/*",
-                                "vers:maven/<0.5.1|>=1.2.3",
-                                "vers:maven/!=3.2.1",
-                                "vers:maven/<6.6.6")),
+                        "vers:maven/<0.5.1|>=1.2.3|!=3.2.1|<6.6.6",
+                        List.of("vers:maven/<0.5.1|>=1.2.3", "vers:maven/!=3.2.1", "vers:maven/<6.6.6")),
                 arguments(
                         "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6",
                         List.of("vers:pypi/>0.0.0|<0.0.5", "vers:pypi/>=0.0.6")),
@@ -242,7 +238,7 @@ class VersTest {
         "'vers:generic/<1.5.0|>=2.0.0|!=2.7.0|<3.2.0', 'vers:generic/>=1.5.0|<2.0.0|2.7.0|>=3.2.0'",
         "'vers:generic/>=1.0.0|!=1.5.0|<2.5.0|>=3.0.0|!=3.2.0', 'vers:generic/<1.0.0|1.5.0|>=2.5.0|<3.0.0|3.2.0'",
         "'vers:generic/>1.2.3|!=2.0.0|<=3.5.1|3.6.2|>4.0.0|<5.0.0', 'vers:generic/<=1.2.3|2.0.0|>3.5.1|!=3.6.2|<=4.0.0|>=5.0.0'",
-        "'vers:generic/>=1.1.0|<2.2.0|!=2.1.0|>=3.0.0|<4.0.0', 'vers:generic/<1.1.0|>=2.2.0|<3.0.0|>=4.0.0'"
+        "'vers:generic/>=1.1.0|<2.2.0|!=2.1.0|>=3.0.0|<4.0.0', 'vers:generic/<1.1.0|2.1.0|>=2.2.0|<3.0.0|>=4.0.0'"
     })
     void testInvert(String version, String expectedInverted) {
         var v = Vers.parse(version);


### PR DESCRIPTION
Caught a bug where the spec expects constraints to be sorted during parse.