### PR TITLE
Make `Vers#parse` reject non-canonical vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ class ConstructVers {
 
 `vers` ranges may
 be [parsed](https://github.com/package-url/vers-spec/blob/main/docs/how-to-parse.md)
-using the `Vers#parse` method. If the range turns out to be invalid, a `VersException` is thrown.
+using the `Vers#parse` method. Per the specification, the input must already be in canonical
+form. Non-canonical input (whitespace, leading, trailing or consecutive pipes, unsorted or
+duplicate constraints, or invalid comparator sequences) is rejected with a `VersException`.
+
+To accept possibly non-canonical input, use `Vers#parseLenient`, which normalizes the range
+(sorting constraints by version, stripping leading and trailing pipes, and trimming whitespace)
+instead of rejecting it.
 
 ```java
 import io.github.nscuro.versatile.Vers;
@@ -111,7 +117,7 @@ import io.github.nscuro.versatile.Vers;
 class SimplifyVers {
 
     void shouldSimplify() {
-        Vers vers = Vers.parse("vers:golang/>v0.0.0|>=v0.0.1|v0.0.2|<v0.0.3|v0.0.4|<v0.0.5|>=v0.0.6");
+        Vers vers = Vers.parseLenient("vers:golang/>v0.0.0|>=v0.0.1|v0.0.2|<v0.0.3|v0.0.4|<v0.0.5|>=v0.0.6");
 
         assert "vers:golang/>v0.0.0|<v0.0.5|>=v0.0.6".equals(vers.simplify().toString());
     }

--- a/versatile-benchmark/src/main/java/io/github/nscuro/versatile/benchmark/VersParsingBenchmark.java
+++ b/versatile-benchmark/src/main/java/io/github/nscuro/versatile/benchmark/VersParsingBenchmark.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(2)
-public class VersOperationsBenchmark {
+public class VersParsingBenchmark {
 
     @Param({
         "apk",
@@ -56,15 +56,27 @@ public class VersOperationsBenchmark {
     })
     private String scheme;
 
-    private Vers vers;
+    private String canonicalRange;
+    private String nonCanonicalRange;
 
     @Setup
     public void setup() {
-        this.vers = Vers.parseLenient("vers:%s/>=1.0.0|<2.0.0|>=3.0.0|<4.0.0|!=2.5.0".formatted(scheme));
+        this.canonicalRange = "vers:%s/>=1.0.0|<2.0.0|!=2.5.0|>=3.0.0|<4.0.0".formatted(scheme);
+        this.nonCanonicalRange = "vers:%s/<4.0.0|>=3.0.0|!=2.5.0|<2.0.0|>=1.0.0".formatted(scheme);
     }
 
     @Benchmark
-    public Vers simplify() {
-        return vers.simplify();
+    public Vers parseStrict() {
+        return Vers.parse(canonicalRange);
+    }
+
+    @Benchmark
+    public Vers parseLenientCanonical() {
+        return Vers.parseLenient(canonicalRange);
+    }
+
+    @Benchmark
+    public Vers parseLenientNonCanonical() {
+        return Vers.parseLenient(nonCanonicalRange);
     }
 }

--- a/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
+++ b/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
@@ -19,12 +19,14 @@
 package io.github.nscuro.versatile.conformance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.nscuro.versatile.Vers;
+import io.github.nscuro.versatile.VersException;
 import io.github.nscuro.versatile.VersionFactory;
 import io.github.nscuro.versatile.conformance.schema.VersTest;
 import io.github.nscuro.versatile.conformance.schema.VersTestSchema01;
@@ -60,7 +62,7 @@ class VersConformanceTest {
             public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
                 if (!attrs.isDirectory()
                         && file.getFileName().toString().endsWith("_test.json")
-                        && file.getFileName().toString().matches("^(?:alpine|maven|nuget|pypi)_.+\\.json$")) {
+                        && file.getFileName().toString().matches("^(?:alpine|maven|nuget|pypi|vers)_.+\\.json$")) {
                     testFilePaths.add(file);
                 }
                 return FileVisitResult.CONTINUE;
@@ -103,6 +105,7 @@ class VersConformanceTest {
             case COMPARISON -> testComparison(versTest);
             case CONTAINMENT -> testContainment(versTest);
             case EQUALITY -> testEquality(versTest);
+            case PARSE -> testParse(versTest);
             case ROUNDTRIP -> testRoundtrip(versTest);
             default -> Assumptions.assumeTrue(false, "Test type not supported yet");
         }
@@ -166,8 +169,38 @@ class VersConformanceTest {
         final var expectedOutput = (Boolean) versTest.getAdditionalProperties().get("expected_output");
         assertThat(expectedOutput).isNotNull();
 
-        final var vers = Vers.parse(versStr);
+        // NB: Containment fixtures include non-canonical (e.g. unsorted) ranges, so parse leniently.
+        final var vers = Vers.parseLenient(versStr);
         assertThat(vers.contains(versionStr)).as(versTest.getDescription()).isEqualTo(expectedOutput);
+    }
+
+    @SuppressWarnings("unchecked")
+    void testParse(final VersTest versTest) {
+        assertThat(versTest.getAdditionalProperties()).isNotNull();
+
+        final var input = (String) versTest.getAdditionalProperties().get("input");
+        assertThat(input).isNotNull();
+
+        if (Boolean.TRUE.equals(versTest.getExpectedFailure())) {
+            assertThatExceptionOfType(VersException.class)
+                    .as(versTest.getDescription())
+                    .isThrownBy(() -> Vers.parse(input));
+            return;
+        }
+
+        final var expectedOutput =
+                (Map<String, Object>) versTest.getAdditionalProperties().get("expected_output");
+        assertThat(expectedOutput).isNotNull();
+
+        final var vers = Vers.parse(input);
+        assertThat(vers.scheme()).as(versTest.getDescription()).isEqualTo(expectedOutput.get("scheme"));
+
+        final var expectedConstraints = (List<List<String>>) expectedOutput.get("version_constraints");
+        final List<List<String>> actualConstraints = vers.constraints().stream()
+                .map(constraint -> List.of(
+                        constraint.comparator().operator(), constraint.version().toString()))
+                .toList();
+        assertThat(actualConstraints).as(versTest.getDescription()).isEqualTo(expectedConstraints);
     }
 
     @SuppressWarnings("unchecked")
@@ -212,6 +245,9 @@ class VersConformanceTest {
         final var expectedOutput = (String) versTest.getAdditionalProperties().get("expected_output");
         assertThat(expectedOutput).isNotNull();
 
-        assertThat(Vers.parse(versStr).toString()).as(versTest.getDescription()).isEqualTo(expectedOutput);
+        // NB: Roundtrip is an "advanced" capability that normalizes non-canonical input.
+        assertThat(Vers.parseLenient(versStr).toString())
+                .as(versTest.getDescription())
+                .isEqualTo(expectedOutput);
     }
 }

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/Comparator.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/Comparator.java
@@ -39,7 +39,7 @@ public enum Comparator {
         this.operator = operator;
     }
 
-    String operator() {
+    public String operator() {
         return operator;
     }
 }

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
@@ -46,46 +46,125 @@ public record Vers(String scheme, List<Constraint> constraints) {
         }
     }
 
-    public static Vers parse(final String versString) {
+    /**
+     * Parses a canonical {@code vers} string.
+     * <p>
+     * Per the vers specification, a {@code vers} string shall already be in canonical form.
+     * {@code versString} values with the following properties are rejected:
+     * <ul>
+     *   <li>whitespace</li>
+     *   <li>leading, trailing, or consecutive pipes</li>
+     *   <li>unsorted constraints</li>
+     *   <li>duplicate constraints</li>
+     *   <li>invalid comparator sequences</li>
+     * </ul>
+     * <p>
+     * Use {@link #parseLenient(String)} if inputs may be non-canonical.
+     *
+     * @throws VersException if the provided value is not a valid {@code vers} range.
+     * @see #parseLenient(String)
+     * @since 0.20.0
+     */
+    public static Vers parse(String versString) {
+        return parse(versString, /* strict */ true);
+    }
+
+    /**
+     * Parses a possibly non-canonical {@code vers} string, normalizing it instead of rejecting it
+     * by sorting constraints, stripping leading and trailing pipes, and trimming whitespace.
+     * <p>
+     * Unlike {@link #parse(String)}, this does not enforce the spec's canonical-form rules.
+     * It is meant for flexible parsing of externally-sourced ranges that may not be normalized.
+     *
+     * @throws VersException if the provided value is not a valid {@code vers} range.
+     * @see <a href="https://github.com/package-url/vers-spec/issues/69">vers-spec#69</a>
+     * @since 0.20.0
+     */
+    public static Vers parseLenient(String versString) {
+        return parse(versString, /* strict */ false);
+    }
+
+    private static Vers parse(final String versString, final boolean strict) {
         if (versString == null || versString.isBlank()) {
             throw new VersException("vers string must not be null or blank");
+        }
+        if (strict && containsWhitespace(versString)) {
+            throw new VersException("vers string must not contain whitespace: \"%s\"".formatted(versString));
         }
 
         String[] parts = versString.split(":", 2);
         if (parts.length != 2) {
-            throw new VersException("vers string does not contain a URI scheme separator");
+            throw new VersException(
+                    "vers string does not contain a URI scheme separator: \"%s\"".formatted(versString));
         }
 
         if (!"vers".equals(parts[0])) {
-            throw new VersException("URI scheme must be \"vers\", but is \"%s\"".formatted(parts[0]));
+            throw new VersException(
+                    "URI scheme must be \"vers\", but is \"%s\" in \"%s\"".formatted(parts[0], versString));
         }
 
         parts = parts[1].split("/", 2);
         if (parts.length != 2) {
-            throw new VersException("vers string does not contain a versioning scheme separator");
+            throw new VersException(
+                    "vers string does not contain a versioning scheme separator: \"%s\"".formatted(versString));
         }
 
         final String scheme = parts[0];
         if (scheme.isBlank()) {
-            throw new VersException("scheme must not be blank");
+            throw new VersException("scheme must not be blank in \"%s\"".formatted(versString));
         }
 
-        final String constraintsString = parts[1].replaceAll("^\\|+", "").replaceAll("\\|+$", "");
+        String constraintsString = parts[1];
         if ("*".equals(constraintsString)) {
             return new Vers(scheme, List.of(new Constraint(scheme, Comparator.WILDCARD, null)));
         }
 
-        parts = constraintsString.split("\\|");
-        if (parts.length == 0) {
-            throw new VersException("vers string contains no constraints");
+        if (strict) {
+            if (constraintsString.startsWith("|")) {
+                throw new VersException("constraints must not start with a pipe in \"%s\"".formatted(versString));
+            }
+            if (constraintsString.endsWith("|")) {
+                throw new VersException("constraints must not end with a pipe in \"%s\"".formatted(versString));
+            }
+            if (constraintsString.contains("||")) {
+                throw new VersException(
+                        "constraints must not contain consecutive pipes in \"%s\"".formatted(versString));
+            }
+        } else {
+            constraintsString = constraintsString.replaceAll("^\\|+", "").replaceAll("\\|+$", "");
         }
 
-        final List<Constraint> constraints = Arrays.stream(parts)
-                .map(part -> Constraint.parse(scheme, part))
-                .sorted()
-                .toList();
+        parts = constraintsString.split("\\|");
+        if (parts.length == 0) {
+            throw new VersException("vers string contains no constraints: \"%s\"".formatted(versString));
+        }
 
-        return new Vers(scheme, constraints);
+        Stream<Constraint> constraintStream = Arrays.stream(parts).map(part -> Constraint.parse(scheme, part));
+        if (!strict) {
+            constraintStream = constraintStream.sorted();
+        }
+        final List<Constraint> constraints = constraintStream.toList();
+
+        if (!strict) {
+            return new Vers(scheme, constraints);
+        }
+
+        for (int i = 0; i + 1 < constraints.size(); i++) {
+            final Constraint curr = constraints.get(i);
+            final Constraint next = constraints.get(i + 1);
+            final int cmp = curr.compareTo(next);
+            if (cmp > 0) {
+                throw new VersException("constraints must be sorted by version, but \"%s\" precedes \"%s\" in \"%s\""
+                        .formatted(curr, next, versString));
+            }
+            if (cmp == 0) {
+                throw new VersException(
+                        "version \"%s\" must occur only once, but is used by both \"%s\" and \"%s\" in \"%s\""
+                                .formatted(curr.version(), curr, next, versString));
+            }
+        }
+
+        return new Vers(scheme, constraints).validate();
     }
 
     public List<Vers> split() {
@@ -340,6 +419,15 @@ public record Vers(String scheme, List<Constraint> constraints) {
         return new Vers(scheme, simplifiedConstraints);
     }
 
+    /**
+     * Validates itself against the {@code vers} spec's rules.
+     * <p>
+     * <strong>Note:</strong> since version 0.20.0, validation is performed implicitly
+     * by {@link #parse(String)}, {@link #parseLenient(String)}, and {@link Builder#build()}.
+     * Calling it separately is not necessary.
+     *
+     * @return the validated {@link Vers}.
+     */
     public Vers validate() {
         // The special star "*" comparator matches any version.
         // It must be used alone exclusive of any other constraint and must not be followed by a version.
@@ -613,6 +701,16 @@ public record Vers(String scheme, List<Constraint> constraints) {
             constraints = constraints.stream().filter(c -> !c.equals(last)).toList();
         }
         return constraints;
+    }
+
+    private static boolean containsWhitespace(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isWhitespace(value.charAt(i))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static class Builder {

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
@@ -61,6 +61,62 @@ class VersTest {
                         });
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "vers:npm/>=1.0.0| <2.0.0", // whitespace
+        "nonsense", // missing URI scheme separator
+        "foo:npm/>=1.0.0", // wrong URI scheme
+        "vers:npmnoslash", // missing versioning scheme separator
+        "vers:/>=1.0.0", // blank scheme
+        "vers:npm/|>=1.0.0|<2.0.0", // leading pipe
+        "vers:npm/>=1.0.0|<2.0.0|", // trailing pipe
+        "vers:npm/>=1.0.0||<2.0.0", // consecutive pipes
+        "vers:npm/>=2.0.0|<1.0.0", // unsorted
+        "vers:npm/>=1.0.0|<=1.0.0", // duplicate version
+        "vers:npm/<1.0.0|<2.0.0", // invalid comparator sequence
+    })
+    void testParseRejectsNonCanonicalWithContext(String input) {
+        assertThatThrownBy(() -> Vers.parse(input))
+                .isInstanceOf(VersException.class)
+                .hasMessageContaining(input);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "vers:npm/>=2.0.0|<1.0.0,vers:npm/<1.0.0|>=2.0.0", // unsorted -> sorted
+        "vers:npm/|>=1.0.0|<2.0.0,vers:npm/>=1.0.0|<2.0.0", // leading pipe stripped
+        "vers:npm/>=1.0.0|<2.0.0|,vers:npm/>=1.0.0|<2.0.0", // trailing pipe stripped
+    })
+    void testParseLenientNormalizesNonCanonical(String input, String expected) {
+        final Vers vers = Vers.parseLenient(input);
+
+        final String normalized = vers.toString();
+        assertThat(normalized).hasToString(expected);
+
+        // Sanity check: must survive strict parsing.
+        assertThatNoException().isThrownBy(() -> Vers.parse(normalized));
+    }
+
+    @Test
+    void testParseUnsortedNamesOffendingConstraints() {
+        assertThatThrownBy(() -> Vers.parse("vers:npm/>=2.0.0|<1.0.0"))
+                .isInstanceOf(VersException.class)
+                .hasMessage("""
+                        constraints must be sorted by version, but ">=2.0.0" \
+                        precedes "<1.0.0" in "vers:npm/>=2.0.0|<1.0.0"\
+                        """);
+    }
+
+    @Test
+    void testParseDuplicateNamesOffendingConstraints() {
+        assertThatThrownBy(() -> Vers.parse("vers:npm/>=1.0.0|<=1.0.0"))
+                .isInstanceOf(VersException.class)
+                .hasMessage("""
+                        version "1.0.0" must occur only once, but is used by \
+                        both ">=1.0.0" and "<=1.0.0" in "vers:npm/>=1.0.0|<=1.0.0"\
+                        """);
+    }
+
     @Test
     void testBuild() {
         final Vers vers = Vers.builder("maven")
@@ -87,7 +143,7 @@ class VersTest {
                 "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3,vers:pypi/>0.0.0|<=0.0.6|!=0.7|8.0|>12|<15.3"
             })
     void testSimplify(final String before, final String after) {
-        final Vers vers = Vers.parse(before).simplify();
+        final Vers vers = Vers.parseLenient(before).simplify();
         assertThat(vers).hasToString(after);
         assertThatNoException().isThrownBy(vers::validate);
     }
@@ -120,7 +176,7 @@ class VersTest {
     @ParameterizedTest
     @MethodSource("testSplitArguments")
     void testSplit(final String inputVers, final List<String> versList) {
-        final var parsedVers = Vers.parse(inputVers);
+        final var parsedVers = Vers.parseLenient(inputVers);
         assertThat(parsedVers.split().stream().map(Vers::toString)).containsAll(versList);
     }
 
@@ -160,9 +216,9 @@ class VersTest {
             })
     void testContains(final String range, final ContainsExpectation expectation, final String version) {
         if (expectation == ContainsExpectation.CONTAINS) {
-            assertThat(Vers.parse(range).contains(version)).isTrue();
+            assertThat(Vers.parseLenient(range).contains(version)).isTrue();
         } else {
-            assertThat(Vers.parse(range).contains(version)).isFalse();
+            assertThat(Vers.parseLenient(range).contains(version)).isFalse();
         }
     }
 
@@ -208,8 +264,8 @@ class VersTest {
         "'vers:generic/>1.2.3|<1.3.1|>1.7', 'vers:generic/>1.3.2|<1.3.4|<1.8', true"
     })
     void testHasOverlap(String version1, String version2, boolean expected) {
-        var v1 = Vers.parse(version1);
-        var v2 = Vers.parse(version2);
+        var v1 = Vers.parseLenient(version1);
+        var v2 = Vers.parseLenient(version2);
         assertThat(v1.overlapsWith(v2)).isEqualTo(expected);
         assertThat(v2.overlapsWith(v1)).isEqualTo(expected);
     }
@@ -241,7 +297,7 @@ class VersTest {
         "'vers:generic/>=1.1.0|<2.2.0|!=2.1.0|>=3.0.0|<4.0.0', 'vers:generic/<1.1.0|2.1.0|>=2.2.0|<3.0.0|>=4.0.0'"
     })
     void testInvert(String version, String expectedInverted) {
-        var v = Vers.parse(version);
+        var v = Vers.parseLenient(version);
         var inverted = v.invert();
         assertThat(inverted.toString()).isEqualTo(expectedInverted);
     }
@@ -273,7 +329,7 @@ class VersTest {
         "'vers:generic/>=1.1.0|<2.2.0|!=2.1.0|>=3.0.0|<4.0.0'"
     })
     void testInvertedDoesNotOverlap(String version) {
-        var v = Vers.parse(version);
+        var v = Vers.parseLenient(version);
         var inverted = v.invert();
         assertThat(v.overlapsWith(inverted)).isEqualTo(false);
     }


### PR DESCRIPTION
Aligns with the spec's decision to require strict parsing (i.e. rejection of non-canonical vers strings) by default: https://github.com/package-url/vers-spec/issues/50

Enables the `canonical_parse` conformance test suite accordingly.

Adds `Vers#parseLenient` as fallback for consumers who are dealing with vers ranges from 3rd parties. Note that the spec may formalize this eventually as hinted at in https://github.com/package-url/vers-spec/issues/69