### PR TITLE
Remove packageurl-java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <lib.maven-artifact.version>3.9.16</lib.maven-artifact.version>
         <lib.nullaway.version>0.13.8</lib.nullaway.version>
         <lib.open-vulnerability-clients.version>9.0.6</lib.open-vulnerability-clients.version>
-        <lib.packageurl-java.version>1.5.0</lib.packageurl-java.version>
         <lib.palantir-java-format.version>2.93.0</lib.palantir-java-format.version>
         <lib.semver4j.version>3.1.0</lib.semver4j.version>
         <lib.slf4j.version>2.0.18</lib.slf4j.version>
@@ -78,12 +77,6 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
                 <version>${lib.maven-artifact.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.package-url</groupId>
-                <artifactId>packageurl-java</artifactId>
-                <version>${lib.packageurl-java.version}</version>
             </dependency>
 
             <dependency>

--- a/versatile-core/pom.xml
+++ b/versatile-core/pom.xml
@@ -32,11 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.package-url</groupId>
-            <artifactId>packageurl-java</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.vdurmont</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/version/KnownVersioningSchemes.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/version/KnownVersioningSchemes.java
@@ -18,10 +18,6 @@
  */
 package io.github.nscuro.versatile.version;
 
-import static java.util.Objects.requireNonNull;
-
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 
@@ -47,40 +43,6 @@ public final class KnownVersioningSchemes {
     public static final String SCHEME_RPM = "rpm";
 
     private KnownVersioningSchemes() {}
-
-    /**
-     * Attempt to match a given Package URL with any of the versioning schemes known to versatile.
-     *
-     * @param purl The Package URL to match
-     * @return An {@link Optional} containing the matched scheme, otherwise an empty {@link Optional}
-     * @throws IllegalArgumentException When the provided {@code purl} is invalid
-     * @see #fromPurl(PackageURL)
-     * @since 0.9.0
-     */
-    public static Optional<String> fromPurl(String purl) {
-        try {
-            return fromPurl(new PackageURL(purl));
-        } catch (MalformedPackageURLException e) {
-            throw new IllegalArgumentException("The provided purl is invalid: " + purl, e);
-        }
-    }
-
-    /**
-     * Attempt to match a given {@link PackageURL} with any of the versioning schemes known to versatile.
-     *
-     * @param purl The {@link PackageURL} to match
-     * @return An {@link Optional} containing the matched scheme, otherwise an empty {@link Optional}
-     * @see #fromPurlType(String)
-     * @since 0.9.0
-     */
-    public static Optional<String> fromPurl(PackageURL purl) {
-        requireNonNull(purl, "purl must not be null");
-
-        // NB: It may be necessary to inspect more than just the type to
-        // determine the versioning scheme.
-
-        return fromPurlType(purl.getType());
-    }
 
     /**
      * Attempt to match a given PURL type with any of the versioning schemes known to versatile.

--- a/versatile-core/src/main/java/module-info.java
+++ b/versatile-core/src/main/java/module-info.java
@@ -36,7 +36,6 @@ module io.github.nscuro.versatile.core {
 
     requires io.github.nscuro.versatile.spi;
     requires maven.artifact;
-    requires packageurl.java;
     requires semver4j;
     requires transitive org.jspecify;
 

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/version/KnownVersioningSchemesTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/version/KnownVersioningSchemesTest.java
@@ -28,37 +28,34 @@ import org.junit.jupiter.params.provider.CsvSource;
 class KnownVersioningSchemesTest {
 
     @Nested
-    class FromPurlTest {
+    class FromPurlTypeTest {
 
         @ParameterizedTest
         @CsvSource({
-            "pkg:apk/alpine/curl@7.83.0-r0, apk",
-            "pkg:cargo/rand@0.7.3, cargo",
-            "pkg:cpan/DROLSKY/DateTime@1.55, cpan",
-            "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1, maven",
-            "pkg:gradle/org.apache.xmlgraphics/batik-anim@1.9.1, maven",
-            "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1, maven",
-            "pkg:deb/debian/curl@7.50.3-1, deb",
-            "pkg:gem/ruby-advisory-db-check@0.12.4, gem",
-            "pkg:generic/openssl@1.1.10g, generic",
-            "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c, golang",
-            "pkg:npm/%40angular/animation@12.3.1, npm",
-            "pkg:nuget/EnterpriseLibrary.Common@6.0.1304, nuget",
-            "pkg:pypi/django-allauth@12.23, pypi",
-            "pkg:rpm/fedora/curl@7.50.3-1.fc25, rpm"
+            "apk, apk",
+            "cargo, cargo",
+            "cpan, cpan",
+            "maven, maven",
+            "gradle, maven",
+            "maven, maven",
+            "deb, deb",
+            "gem, gem",
+            "generic, generic",
+            "golang, golang",
+            "npm, npm",
+            "nuget, nuget",
+            "pypi, pypi",
+            "rpm, rpm"
         })
-        void shouldReturnMatchingScheme(final String purl, final String expectedScheme) {
-            assertThat(KnownVersioningSchemes.fromPurl(purl)).contains(expectedScheme);
+        void shouldReturnMatchingScheme(String purl, String expectedScheme) {
+            assertThat(KnownVersioningSchemes.fromPurlType(purl)).contains(expectedScheme);
         }
 
         @Test
         void shouldReturnEmptyOptionalForUnknown() {
-            assertThat(KnownVersioningSchemes.fromPurl("pkg:foobar/baz@1.2.3")).isEmpty();
+            assertThat(KnownVersioningSchemes.fromPurlType("pkg:foobar/baz@1.2.3"))
+                    .isEmpty();
         }
-    }
-
-    @Nested
-    class FromPurlTypeTest {
 
         @Test
         void shouldReturnEmptyOptionalForNull() {


### PR DESCRIPTION
Also removes the associated `KnownVersioningSchemes#fromPurl` methods. Consumers should switch to `#fromPurlType`.