### PR TITLE
Fix range simplification not collapsing multiple same-direction bounds

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/Vers.java
@@ -373,16 +373,24 @@ public record Vers(String scheme, List<Constraint> constraints) {
             final Comparator currComparator = currConstraint.comparator();
             final Comparator nextComparator = nextConstraint.comparator();
 
+            // NB: The spec does not say what happens to the cursor when a constraint is discarded.
+            // Advancing unconditionally leaves runs of same-direction bounds behind
+            // (e.g. ">=1|>=2|>=3" would simplify to the invalid ">=1|>=3"), so the current
+            // and next constraints are re-considered until no more of them can be discarded.
+            boolean discarded = false;
+
             // If current comparator is ">" or ">=" and next comparator is "=", ">" or ">=", discard next constraint.
             if (isLowerBoundComparator(currComparator)
                     && (nextComparator == Comparator.EQUAL || isLowerBoundComparator(nextComparator))) {
                 remainderConstraints.remove(nextIndex);
+                discarded = true;
             }
 
             // If current comparator is "=", "<" or "<=" and next comparator is <" or <=", discard current constraint.
             if ((currComparator == Comparator.EQUAL || isUpperBoundComparator(currComparator))
                     && isUpperBoundComparator(nextComparator)) {
                 remainderConstraints.remove(currIndex);
+                discarded = true;
 
                 // Previous constraint becomes current if it exists.
                 if (currIndex > 0) {
@@ -392,25 +400,36 @@ public record Vers(String scheme, List<Constraint> constraints) {
 
             // If there is a previous constraint:
             if (currIndex > 0) {
-                final Constraint prevConstraint = remainderConstraints.get(currIndex - 1);
-                final Comparator prevComparator = prevConstraint.comparator();
+                final Comparator prevComparator =
+                        remainderConstraints.get(currIndex - 1).comparator();
+
+                // NB: The rules above may have discarded the current constraint, in which case
+                // currIndex now points to a different one. Look up its comparator again instead of
+                // reusing currComparator, which may be stale.
+                final Comparator comparator =
+                        remainderConstraints.get(currIndex).comparator();
 
                 // If previous comparator is ">" or ">=" and current comparator is "=", ">" or ">=",
                 // discard current constraint.
                 if (isLowerBoundComparator(prevComparator)
-                        && (currComparator == Comparator.EQUAL || isLowerBoundComparator(currComparator))) {
+                        && (comparator == Comparator.EQUAL || isLowerBoundComparator(comparator))) {
                     remainderConstraints.remove(currIndex);
+                    discarded = true;
                 }
 
                 // If previous comparator is "=", "<" or "<=" and current comparator is <" or <=",
                 // discard previous constraint.
-                if ((prevComparator == Comparator.EQUAL || isUpperBoundComparator(prevComparator))
-                        && isUpperBoundComparator(currComparator)) {
-                    remainderConstraints.remove(prevConstraint);
+                else if ((prevComparator == Comparator.EQUAL || isUpperBoundComparator(prevComparator))
+                        && isUpperBoundComparator(comparator)) {
+                    remainderConstraints.remove(currIndex - 1);
+                    discarded = true;
+                    currIndex -= 1;
                 }
             }
 
-            currIndex++;
+            if (!discarded) {
+                currIndex++;
+            }
         }
 
         // Concatenate the "unequal constraints" list and the filtered "constraints" list.

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersTest.java
@@ -149,7 +149,20 @@ class VersTest {
             value = {
                 "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6,vers:pypi/>0.0.0|<0.0.5|>=0.0.6",
                 "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8,vers:pypi/>0.0.0|<0.0.5|>=0.0.6|!=0.8",
-                "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3,vers:pypi/>0.0.0|<=0.0.6|!=0.7|8.0|>12|<15.3"
+                "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3,vers:pypi/>0.0.0|<=0.0.6|!=0.7|8.0|>12|<15.3",
+                // Runs of same-direction bounds must collapse entirely, no matter their length.
+                "vers:generic/>=1|>=2,vers:generic/>=1",
+                "vers:generic/>=1|>=2|>=3,vers:generic/>=1",
+                "vers:generic/>=1|>=2|>=3|>=4,vers:generic/>=1",
+                "vers:generic/>=1|>=2|>=3|>=4|>=5,vers:generic/>=1",
+                "vers:generic/<1|<2,vers:generic/<2",
+                "vers:generic/<1|<2|<3,vers:generic/<3",
+                "vers:generic/<1|<2|<3|<4,vers:generic/<4",
+                "vers:generic/<1|<2|<3|<4|<5,vers:generic/<5",
+                // Runs surrounded by bounds of the opposite direction must not swallow those.
+                "vers:generic/<1|>=2|>=3|<4,vers:generic/<1|>=2|<4",
+                "vers:generic/>=1|2|>=3|<4,vers:generic/>=1|<4",
+                "vers:generic/<1|<2|>=3|<4|<5|>=6,vers:generic/<2|>=3|<5|>=6"
             })
     void testSimplify(final String before, final String after) {
         final Vers vers = Vers.parseLenient(before).simplify();


### PR DESCRIPTION
Ranges like `>=1|>=2|>=3` left behind `>=1|>=3` when it should have been `>=1`. This is not explicitly called out in the spec, so our original implementation didn't handle it.