### PR TITLE
Improve OSV ecosystem mapping

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
@@ -21,12 +21,15 @@ package io.github.nscuro.versatile;
 import io.github.nscuro.versatile.spi.InvalidVersionException;
 import io.github.nscuro.versatile.version.KnownVersioningSchemes;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 public final class VersUtils {
+
+    private static final Set<String> NESTING_OSV_ECOSYSTEMS = Set.of("echo", "root", "tuxcare");
 
     private VersUtils() {}
 
@@ -101,7 +104,8 @@ public final class VersUtils {
             throw new IllegalArgumentException("Range type \"%s\" is not supported".formatted(type));
         }
 
-        final var scheme = schemeFromOsvEcosystem(ecosystem).orElse(ecosystem);
+        // The suffix is not part of the ecosystem name, and thus must not end up in the scheme.
+        final var scheme = schemeFromOsvEcosystem(ecosystem).orElseGet(() -> osvEcosystemNameOf(ecosystem));
         final var versBuilder = Vers.builder(scheme);
         int constraintCount = 0;
 
@@ -240,34 +244,55 @@ public final class VersUtils {
 
     public static Optional<String> schemeFromOsvEcosystem(String ecosystem) {
         // https://github.com/ossf/osv-schema/blob/main/docs/schema.md#affectedpackage-field
+        final String[] segments = ecosystem.split(":", 3);
 
-        // NB: Linux distros can have an optional ":<RELEASE>" suffix.
-        if (ecosystem.startsWith("AlmaLinux")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_RPM);
-        } else if (ecosystem.startsWith("Alpine")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_APK);
-        } else if (ecosystem.startsWith("Debian")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_DEBIAN);
-        } else if (ecosystem.startsWith("Mageia")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_RPM);
-        } else if (ecosystem.startsWith("Photon OS")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_RPM);
-        } else if (ecosystem.startsWith("Rocky Linux")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_RPM);
-        } else if (ecosystem.startsWith("Ubuntu")) {
-            return Optional.of(KnownVersioningSchemes.SCHEME_DEBIAN);
+        // For nesting ecosystems the second segment names the re-packaged ecosystem,
+        // e.g. "TuxCare:Ubuntu:16.04". For all others it is a release, repository URL,
+        // or CPE, which must not be interpreted as an ecosystem.
+        if (segments.length > 1 && NESTING_OSV_ECOSYSTEMS.contains(segments[0].toLowerCase())) {
+            return schemeFromOsvEcosystemName(segments[1]).or(() -> schemeFromOsvEcosystemName(segments[0]));
         }
 
-        return switch (ecosystem.toLowerCase()) {
+        return schemeFromOsvEcosystemName(segments[0]);
+    }
+
+    private static Optional<String> schemeFromOsvEcosystemName(String name) {
+        return switch (name.toLowerCase(Locale.ROOT)) {
+            case "almalinux",
+                    "azure linux",
+                    "centos",
+                    "centos-stream",
+                    "mageia",
+                    "openeuler",
+                    "opensuse",
+                    "oraclelinux",
+                    "photon os",
+                    "red hat",
+                    "rhel",
+                    "rocky linux",
+                    "suse" -> Optional.of(KnownVersioningSchemes.SCHEME_RPM);
+            case "alpaquita",
+                    "alpine",
+                    "bellsoft hardened containers",
+                    "chainguard",
+                    "cleanstart",
+                    "minimos",
+                    "wolfi" -> Optional.of(KnownVersioningSchemes.SCHEME_APK);
+            case "composer", "packagist" -> Optional.of(KnownVersioningSchemes.SCHEME_COMPOSER);
             case "crates.io" -> Optional.of(KnownVersioningSchemes.SCHEME_CARGO);
+            case "debian", "echo", "ubuntu" -> Optional.of(KnownVersioningSchemes.SCHEME_DEBIAN);
             case "go" -> Optional.of(KnownVersioningSchemes.SCHEME_GOLANG);
             case "maven" -> Optional.of(KnownVersioningSchemes.SCHEME_MAVEN);
             case "npm" -> Optional.of(KnownVersioningSchemes.SCHEME_NPM);
             case "nuget" -> Optional.of(KnownVersioningSchemes.SCHEME_NUGET);
-            case "packagist" -> Optional.of(KnownVersioningSchemes.SCHEME_COMPOSER);
             case "pypi" -> Optional.of(KnownVersioningSchemes.SCHEME_PYPI);
-            case "rubygems" -> Optional.of(KnownVersioningSchemes.SCHEME_GEM);
+            case "ruby", "rubygems" -> Optional.of(KnownVersioningSchemes.SCHEME_GEM);
             default -> Optional.empty();
         };
+    }
+
+    private static String osvEcosystemNameOf(String ecosystem) {
+        final int suffixIndex = ecosystem.indexOf(':');
+        return suffixIndex != -1 ? ecosystem.substring(0, suffixIndex) : ecosystem;
     }
 }

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
@@ -115,6 +115,19 @@ class VersUtilsTest {
     }
 
     @Test
+    void testVersFromOsvRangeWithSuffixedEcosystem() {
+        final List<Map.Entry<String, String>> events =
+                List.of(Map.entry("introduced", "0"), Map.entry("fixed", "1.35.0"));
+
+        assertThat(versFromOsvRange("ecosystem", "Packagist:https://packages.drupal.org/8", events, null))
+                .hasToString("vers:composer/<1.35.0.0");
+        assertThat(versFromOsvRange("ecosystem", "VSCode:https://open-vsx.org", events, null))
+                .hasToString("vers:vscode/<1.35.0");
+        assertThat(versFromOsvRange("ecosystem", "TuxCare:Ubuntu:16.04", events, null))
+                .hasToString("vers:deb/<1.35.0");
+    }
+
+    @Test
     void testVersFromOsvRangeWithInvalidRangeType() {
         final List<Map.Entry<String, String>> events = List.of(Map.entry("introduced", "0"));
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -152,17 +165,31 @@ class VersUtilsTest {
         }
     }
 
+    @Test
+    void testSchemeFromOsvEcosystemDoesNotInferSchemeFromSuffix() {
+        assertThat(schemeFromOsvEcosystem("Alpine:npm")).contains("apk");
+    }
+
     @ParameterizedTest
     @CsvSource(
             value = {
                 "AlmaLinux, rpm",
+                "Alpaquita:23, apk",
                 "Alpine, apk",
                 "Android, ",
+                "Azure Linux:2, rpm",
+                "BellSoft Hardened Containers:stream, apk",
                 "Bioconductor, ",
                 "Bitnami, ",
                 "CRAN, ",
+                "Chainguard, apk",
+                "CleanStart, apk",
                 "ConanCenter, ",
                 "Debian, deb",
+                "Debian:12, deb",
+                "Echo, deb",
+                "Echo:Maven, maven",
+                "Echo:PyPi, pypi",
                 "GHC, ",
                 "GitHub Actions, ",
                 "Go, golang",
@@ -171,16 +198,40 @@ class VersUtilsTest {
                 "Linux, ",
                 "Mageia, rpm",
                 "Maven, maven",
+                "Maven:https://maven.google.com, maven",
+                "MinimOS, apk",
                 "OSS-Fuzz, ",
                 "Packagist, composer",
+                "Packagist:https://packages.drupal.org/8, composer",
                 "Photon OS, rpm",
                 "Pub, ",
                 "PyPI, pypi",
+                "Red Hat:enterprise_linux:7::server, rpm",
                 "Rocky Linux, rpm",
+                "Root:Alpine:3.18, apk",
+                "Root:Composer, composer",
+                "Root:Go, golang",
+                "Root:Ruby, gem",
+                "Root:Ubuntu:22.04, deb",
+                "Root:npm, npm",
                 "RubyGems, gem",
+                "SUSE:Linux Enterprise Module for Public Cloud 15 SP4, rpm",
                 "SwiftURL, ",
+                "TuxCare:CentOS-Stream:8, rpm",
+                "TuxCare:CentOS:8.4, rpm",
+                "TuxCare:Maven, maven",
+                "TuxCare:OracleLinux:6, rpm",
+                "TuxCare:Packagist, composer",
+                "TuxCare:RHEL:7, rpm",
+                "TuxCare:Ubuntu:16.04, deb",
+                "Ubuntu, deb",
+                "Ubuntu:Pro:18.04:LTS, deb",
+                "VSCode:https://open-vsx.org, ",
+                "Wolfi, apk",
                 "crates.io, cargo",
                 "npm, npm",
+                "openEuler:20.03-LTS-SP1, rpm",
+                "openSUSE:Leap 15.3, rpm",
             })
     void testSchemeFromOsvEcosystem(final String ecosystem, final String expectedScheme) {
         if (expectedScheme == null) {


### PR DESCRIPTION
Fixes ecosystems being misclassified due to unexpected suffixes, e.g. `Packagist:https://packages.drupal.org/8`.

Adds coverage of ecosystem <-> versioning scheme mappings based on current OSV data.