### PR TITLE
Align OSV version range mapping with OSV spec

### DIFF
--- a/versatile-core/src/main/java/io/github/nscuro/versatile/OsvRangeConverter.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/OsvRangeConverter.java
@@ -1,0 +1,261 @@
+/*
+ * This file is part of versatile.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Niklas Düster. All Rights Reserved.
+ */
+package io.github.nscuro.versatile;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsFirst;
+
+import io.github.nscuro.versatile.spi.InvalidVersionException;
+import io.github.nscuro.versatile.spi.Version;
+import io.github.nscuro.versatile.version.KnownVersioningSchemes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+
+final class OsvRangeConverter {
+
+    private static final Set<String> UNFIXED_SENTINEL_VERSIONS = Set.of("<end-of-life>", "<unfixed>");
+    private static final String RANGE_EVENT_FIXED = "fixed";
+    private static final String RANGE_EVENT_INTRODUCED = "introduced";
+    private static final String RANGE_EVENT_LAST_AFFECTED = "last_affected";
+    private static final String RANGE_EVENT_LIMIT = "limit";
+
+    private OsvRangeConverter() {}
+
+    static List<Vers> convert(
+            String type,
+            String ecosystem,
+            List<Map.Entry<String, String>> events,
+            @Nullable Map<String, Object> databaseSpecific) {
+        if (!"ecosystem".equalsIgnoreCase(type) && !"semver".equalsIgnoreCase(type)) {
+            throw new IllegalArgumentException("Range type \"%s\" is not supported".formatted(type));
+        }
+
+        // The suffix is not part of the ecosystem name, and thus must not end up in the scheme.
+        final var scheme =
+                VersUtils.schemeFromOsvEcosystem(ecosystem).orElseGet(() -> VersUtils.osvEcosystemNameOf(ecosystem));
+        final List<Map.Entry<String, String>> versionEvents = withoutNonVersionEvents(events);
+
+        try {
+            return versIntervalsOf(versionEvents, scheme, databaseSpecific);
+        } catch (InvalidVersionException e) {
+            // Comparing versions as opaque strings is less precise than an ecosystem's
+            // own rules, but losing the range entirely is worse.
+            if (KnownVersioningSchemes.SCHEME_GENERIC.equals(scheme)) {
+                throw e;
+            }
+
+            return versIntervalsOf(versionEvents, KnownVersioningSchemes.SCHEME_GENERIC, databaseSpecific);
+        }
+    }
+
+    private static List<Vers> versIntervalsOf(
+            List<Map.Entry<String, String>> versionEvents,
+            String scheme,
+            @Nullable Map<String, Object> databaseSpecific) {
+        // Events are not guaranteed to be sorted, the OSV spec merely *recommends* it.
+        // For reliable conversion, we need to sort ourselves.
+        final List<Map.Entry<String, String>> sortedVersionEvents = sortByVersion(versionEvents, scheme);
+
+        final List<Interval> intervals = intervalsOf(sortedVersionEvents, scheme);
+
+        final var versList = new ArrayList<Vers>(intervals.size());
+        for (int i = 0; i < intervals.size(); i++) {
+            final Interval interval = intervals.get(i);
+            final String lastKnownAffectedRange = i == intervals.size() - 1 && interval.upperBound() == null
+                    ? lastKnownAffectedRangeOf(databaseSpecific)
+                    : null;
+
+            versList.add(versFromInterval(interval, scheme, lastKnownAffectedRange));
+        }
+
+        return versList;
+    }
+
+    private record Interval(Map.Entry<String, String> introduced, Map.@Nullable Entry<String, String> upperBound) {}
+
+    private static List<Interval> intervalsOf(List<Map.Entry<String, String>> events, String scheme) {
+        int highestLimitIndex = -1;
+        for (int i = events.size() - 1; i >= 0; i--) {
+            if (RANGE_EVENT_LIMIT.equals(events.get(i).getKey())) {
+                highestLimitIndex = i;
+                break;
+            }
+        }
+
+        final var intervals = new ArrayList<Interval>();
+        Map.Entry<String, String> introduced = null;
+
+        for (int i = 0; i < events.size(); i++) {
+            final Map.Entry<String, String> event = events.get(i);
+            final String eventType = event.getKey();
+
+            if (!isUpperBoundEvent(eventType)) {
+                // An introduced event cannot widen an interval that already started lower.
+                if (introduced == null) {
+                    introduced = event;
+                }
+                continue;
+            }
+
+            // Only the highest limit closes the range.
+            // All others are satisfied by any version below it.
+            if (RANGE_EVENT_LIMIT.equals(eventType) && i != highestLimitIndex) {
+                continue;
+            }
+
+            // Nothing is affected below the first introduced event.
+            if (introduced != null) {
+                // Skip empty intervals such as >=3|<3, they're meaningless.
+                if (!isEmptyInterval(introduced, event, scheme)) {
+                    intervals.add(new Interval(introduced, event));
+                }
+                introduced = null;
+            }
+
+            // Nothing at or above the highest limit is affected.
+            if (i == highestLimitIndex) {
+                return intervals;
+            }
+        }
+
+        if (introduced != null) {
+            intervals.add(new Interval(introduced, null));
+        }
+
+        return intervals;
+    }
+
+    private static boolean isEmptyInterval(
+            Map.Entry<String, String> introduced, Map.Entry<String, String> upperBound, String scheme) {
+        // last_affected is inclusive, so its own version stays affected.
+        if (RANGE_EVENT_LAST_AFFECTED.equals(upperBound.getKey())) {
+            return false;
+        }
+
+        final Version introducedVersion = versionOf(introduced, scheme);
+        return introducedVersion != null
+                && introducedVersion.compareTo(VersionFactory.forScheme(scheme, upperBound.getValue())) == 0;
+    }
+
+    private static Vers versFromInterval(Interval interval, String scheme, @Nullable String lastKnownAffectedRange) {
+        final var versBuilder = Vers.builder(scheme);
+
+        if (!isIntroducedZeroEvent(interval.introduced())) {
+            // introduced=0 is OSV's special value for "before all versions",
+            // see https://ossf.github.io/osv-schema/#special-values
+            versBuilder.withConstraint(
+                    Comparator.GREATER_THAN_OR_EQUAL, interval.introduced().getValue());
+        }
+
+        final Map.Entry<String, String> upperBound = interval.upperBound();
+        if (upperBound != null) {
+            versBuilder.withConstraint(
+                    RANGE_EVENT_LAST_AFFECTED.equals(upperBound.getKey())
+                            ? Comparator.LESS_THAN_OR_EQUAL
+                            : Comparator.LESS_THAN,
+                    upperBound.getValue());
+        } else if (lastKnownAffectedRange != null) {
+            if (lastKnownAffectedRange.startsWith("<=")) {
+                versBuilder.withConstraint(
+                        Comparator.LESS_THAN_OR_EQUAL,
+                        lastKnownAffectedRange.replaceFirst("<=", "").trim());
+            } else if (lastKnownAffectedRange.startsWith("<")) {
+                versBuilder.withConstraint(
+                        Comparator.LESS_THAN,
+                        lastKnownAffectedRange.replaceFirst("<", "").trim());
+            }
+        }
+
+        if (!versBuilder.hasConstraints()) {
+            versBuilder.withConstraint(Comparator.WILDCARD, null);
+        }
+
+        return versBuilder.build();
+    }
+
+    private static List<Map.Entry<String, String>> withoutNonVersionEvents(List<Map.Entry<String, String>> events) {
+        // A limit of "*" means infinity. Because a version only has to be below one limit
+        // to pass the gate, it leaves every other limit in the range without effect.
+        final boolean hasWildcardLimit = events.stream()
+                .anyMatch(event -> RANGE_EVENT_LIMIT.equals(event.getKey()) && "*".equals(event.getValue()));
+
+        final var retainedEvents = new ArrayList<Map.Entry<String, String>>(events.size());
+
+        for (int i = 0; i < events.size(); i++) {
+            final Map.Entry<String, String> event = events.get(i);
+            final String eventType = event.getKey();
+            final String eventVersion = event.getValue();
+
+            if (!RANGE_EVENT_INTRODUCED.equals(eventType) && !isUpperBoundEvent(eventType)) {
+                throw new IllegalArgumentException("Invalid event \"%s\" at position %d".formatted(eventType, i));
+            }
+
+            if (hasWildcardLimit && RANGE_EVENT_LIMIT.equals(eventType)) {
+                continue;
+            }
+
+            // Debian ranges use these to signal that no fix is available, leaving the interval
+            // open. They are not versions in any ecosystem, so the scheme does not matter.
+            if (isUpperBoundEvent(eventType) && UNFIXED_SENTINEL_VERSIONS.contains(eventVersion)) {
+                continue;
+            }
+
+            retainedEvents.add(event);
+        }
+
+        return retainedEvents;
+    }
+
+    private static List<Map.Entry<String, String>> sortByVersion(
+            List<Map.Entry<String, String>> events, String scheme) {
+        final var sortedEvents = new ArrayList<>(events);
+        sortedEvents.sort(comparing(event -> versionOf(event, scheme), nullsFirst(naturalOrder())));
+        return sortedEvents;
+    }
+
+    private static @Nullable Version versionOf(Map.Entry<String, String> event, String scheme) {
+        // introduced=0 sorts before every other version,
+        // and may not even be a valid version for the scheme.
+        return isIntroducedZeroEvent(event) ? null : VersionFactory.forScheme(scheme, event.getValue());
+    }
+
+    private static boolean isUpperBoundEvent(String eventKey) {
+        return RANGE_EVENT_FIXED.equals(eventKey)
+                || RANGE_EVENT_LIMIT.equals(eventKey)
+                || RANGE_EVENT_LAST_AFFECTED.equals(eventKey);
+    }
+
+    private static boolean isIntroducedZeroEvent(Map.Entry<String, String> event) {
+        return RANGE_EVENT_INTRODUCED.equals(event.getKey()) && "0".equals(event.getValue());
+    }
+
+    private static @Nullable String lastKnownAffectedRangeOf(@Nullable Map<String, Object> databaseSpecific) {
+        if (databaseSpecific != null
+                && databaseSpecific.get("last_known_affected_version_range")
+                        instanceof final String lastKnownAffectedRange) {
+            return lastKnownAffectedRange;
+        }
+
+        return null;
+    }
+}

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java
@@ -84,87 +84,37 @@ public final class VersUtils {
     }
 
     /**
-     * Convert a range type, ecosystem, and range events as used by OSV to a {@link Vers} range.
+     * Convert a range type, ecosystem, and range events as used by OSV to {@link Vers} ranges.
+     * <p>
+     * Events are evaluated per OSV's evaluation algorithm, which sorts them by version and
+     * treats {@code limit} events as a range-wide gate rather than an upper bound.
+     * The resulting ranges are ascending and disjoint, and have at most two constraints each.
+     * <p>
+     * An empty {@link List} is returned when the range affects no version at all.
+     * <p>
+     * The {@code last_known_affected_version_range} of {@code databaseSpecific} is not part of the
+     * OSV schema, but a convention of the GitHub advisory database. It is applied to the last range,
+     * and only when that range has no upper bound, so it can never widen the result.
+     * <p>
+     * When a version does not comply with the scheme inferred from {@code ecosystem},
+     * the whole range is converted again under the {@code generic} scheme rather than discarded.
+     * The returned ranges then all carry the {@code generic} scheme.
      *
      * @param type      The type of the range, must be either {@code ECOSYSTEM} or {@code SEMVER}
      * @param ecosystem The ecosystem of the affected package
      * @param events    The events in the range
-     * @return The resulting {@link Vers}
+     * @return The resulting {@link Vers} ranges, one per affected interval
      * @throws IllegalArgumentException When the provided range type is not support supported,
      *                                  or the provided {@code events} contains an invalid event
-     * @throws VersException            When the produced {@link Vers} is invalid
-     * @throws InvalidVersionException  When any version in the range is invalid according to the inferred scheme
+     * @throws InvalidVersionException  When any version in the range is invalid according to the {@code generic} scheme
+     * @see <a href="https://ossf.github.io/osv-schema/#evaluation">OSV evaluation algorithm</a>
      */
-    public static Vers versFromOsvRange(
+    public static List<Vers> versFromOsvRange(
             String type,
             String ecosystem,
             List<Map.Entry<String, String>> events,
             @Nullable Map<String, Object> databaseSpecific) {
-        if (!"ecosystem".equalsIgnoreCase(type) && !"semver".equalsIgnoreCase(type)) {
-            throw new IllegalArgumentException("Range type \"%s\" is not supported".formatted(type));
-        }
-
-        // The suffix is not part of the ecosystem name, and thus must not end up in the scheme.
-        final var scheme = schemeFromOsvEcosystem(ecosystem).orElseGet(() -> osvEcosystemNameOf(ecosystem));
-        final var versBuilder = Vers.builder(scheme);
-        int constraintCount = 0;
-
-        for (int i = 0; i < events.size(); i++) {
-            final Map.Entry<String, String> event = events.get(i);
-
-            final Comparator comparator =
-                    switch (event.getKey()) {
-                        case "introduced" -> Comparator.GREATER_THAN_OR_EQUAL;
-                        case "fixed", "limit" -> Comparator.LESS_THAN;
-                        case "last_affected" -> Comparator.LESS_THAN_OR_EQUAL;
-                        default ->
-                            throw new IllegalArgumentException(
-                                    "Invalid event \"%s\" at position %d".formatted(event.getKey(), i));
-                    };
-
-            if (comparator == Comparator.GREATER_THAN_OR_EQUAL && "0".equals(event.getValue())) {
-                // introduced=0 is OSV's special value for "before all versions",
-                // see https://ossf.github.io/osv-schema/#special-values
-                continue;
-            }
-
-            if ("deb".equals(scheme)
-                    && (comparator == Comparator.LESS_THAN || comparator == Comparator.LESS_THAN_OR_EQUAL)
-                    && Set.of("<end-of-life>", "<unfixed>").contains(event.getValue())) {
-                // Some ranges in the Debian ecosystem use these special values for their upper bound,
-                // to signal that all versions are affected. As they are not valid versions, we skip them.
-                //
-                // introduced=0, fixed=<unfixed> is equivalent to *.
-                continue;
-            }
-
-            versBuilder.withConstraint(comparator, event.getValue());
-            constraintCount++;
-        }
-
-        if (databaseSpecific != null
-                && databaseSpecific.get("last_known_affected_version_range")
-                        instanceof final String lastKnownAffectedRange) {
-            if (lastKnownAffectedRange.startsWith("<=")) {
-                versBuilder.withConstraint(
-                        Comparator.LESS_THAN_OR_EQUAL,
-                        lastKnownAffectedRange.replaceFirst("<=", "").trim());
-                constraintCount++;
-            } else if (lastKnownAffectedRange.startsWith("<")) {
-                versBuilder.withConstraint(
-                        Comparator.LESS_THAN,
-                        lastKnownAffectedRange.replaceFirst("<", "").trim());
-                constraintCount++;
-            }
-        }
-
-        if (constraintCount == 0) {
-            return Vers.builder(scheme)
-                    .withConstraint(Comparator.WILDCARD, null)
-                    .build();
-        }
-
-        return versBuilder.build();
+        return OsvRangeConverter.convert(type, ecosystem, events, databaseSpecific);
     }
 
     /**
@@ -291,7 +241,7 @@ public final class VersUtils {
         };
     }
 
-    private static String osvEcosystemNameOf(String ecosystem) {
+    static String osvEcosystemNameOf(String ecosystem) {
         final int suffixIndex = ecosystem.indexOf(':');
         return suffixIndex != -1 ? ecosystem.substring(0, suffixIndex) : ecosystem;
     }

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsIT.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsIT.java
@@ -23,8 +23,9 @@ import static io.github.nscuro.versatile.VersUtils.versFromGhsaRange;
 import static io.github.nscuro.versatile.VersUtils.versFromOsvRange;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.params.ParameterizedTest.ARGUMENTS_WITH_NAMES_PLACEHOLDER;
+import static org.junit.jupiter.params.ParameterizedInvocationConstants.ARGUMENTS_WITH_NAMES_PLACEHOLDER;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -37,6 +38,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import io.github.jeremylong.openvulnerability.client.ghsa.GitHubSecurityAdvisoryClient;
 import io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory;
 import io.github.jeremylong.openvulnerability.client.ghsa.Vulnerabilities;
+import io.github.nscuro.versatile.version.KnownVersioningSchemes;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -47,6 +49,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -137,7 +140,7 @@ public class VersUtilsIT {
                 "RubyGems",
                 "Ubuntu"
             })
-    void testVersFromOsvRangeWithAllRanges(final String ecosystem) throws Exception {
+    void testVersFromOsvRangeWithAllRanges(String ecosystem) throws Exception {
         final Path tempFile = Files.createTempFile(null, null);
 
         final HttpRequest request = HttpRequest.newBuilder()
@@ -177,6 +180,15 @@ public class VersUtilsIT {
                         continue;
                     }
 
+                    // GitHub records last_known_affected_version_range here, not on the range.
+                    final Map<String, Object> databaseSpecific =
+                            objectMapper.convertValue(affected.get("database_specific"), new TypeReference<>() {});
+
+                    // An advisory in this ecosystem's archive can affect packages of other ecosystems.
+                    // Packages identified by purl alone may not declare one.
+                    final String affectedEcosystem =
+                            affected.path("package").path("ecosystem").asText(ecosystem);
+
                     for (final JsonNode range : ranges) {
                         if ("GIT".equals(range.get("type").asText())) {
                             continue;
@@ -191,15 +203,35 @@ public class VersUtilsIT {
 
                         final ObjectNode objectNode = objectMapper
                                 .createObjectNode()
-                                .put("name", affected.get("package").get("name").asText())
+                                .put("ecosystem", affectedEcosystem)
+                                .put(
+                                        "name",
+                                        affected.path("package").path("name").asText())
                                 .putPOJO("events", events);
 
                         try {
-                            final Vers vers = versFromOsvRange(range.get("type").asText(), ecosystem, events, null)
-                                    .simplify()
-                                    .validate();
+                            final List<Vers> versList =
+                                    versFromOsvRange(
+                                                    range.get("type").asText(),
+                                                    affectedEcosystem,
+                                                    events,
+                                                    databaseSpecific)
+                                            .stream()
+                                            .map(vers -> vers.simplify().validate())
+                                            .toList();
 
-                            resultsArrayNode.add(objectNode.put("vers", vers.toString()));
+                            resultsArrayNode.add(objectNode
+                                    .deepCopy()
+                                    .putPOJO(
+                                            "vers",
+                                            versList.stream()
+                                                    .map(Vers::toString)
+                                                    .toList()));
+
+                            final String violation = invariantViolation(versList);
+                            if (violation != null) {
+                                failuresArrayNode.add(objectNode.put("failureReason", violation));
+                            }
                         } catch (RuntimeException e) {
                             failuresArrayNode.add(objectNode.put("failureReason", e.getMessage()));
                         }
@@ -208,14 +240,60 @@ public class VersUtilsIT {
             }
         }
 
-        try (final var resultsFileOutputStream =
-                        Files.newOutputStream(Paths.get("target/results/osv-%s.json".formatted(ecosystem)));
-                final var failuresFileOutputStream =
-                        Files.newOutputStream(Paths.get("target/results/osv-%s-failures.json".formatted(ecosystem)))) {
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(resultsFileOutputStream, resultsArrayNode);
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(failuresFileOutputStream, failuresArrayNode);
-        }
+        writeResults(objectMapper, ecosystem, "", resultsArrayNode);
+        writeResults(objectMapper, ecosystem, "-failures", failuresArrayNode);
 
         assertThat(failuresArrayNode).isEmpty();
+    }
+
+    private static String invariantViolation(List<Vers> versList) {
+        for (Vers vers : versList) {
+            if (vers.constraints().size() > 2) {
+                return "Range %s has more than two constraints".formatted(vers);
+            }
+
+            try {
+                String reparsed = Vers.parseLenient(vers.toString()).toString();
+
+                // Composer normalization is not idempotent, e.g. `2020-09-14` normalizes to `2020.09.14`,
+                // and `2020.09.14` to `2020.09.14.0`. We intentionally don't "fix" this because Composer
+                // itself doesn't either.
+                if (!KnownVersioningSchemes.SCHEME_COMPOSER.equals(vers.scheme())
+                        && !reparsed.equals(vers.toString())) {
+                    return "Range %s renders as %s after a parse round-trip".formatted(vers, reparsed);
+                }
+            } catch (RuntimeException e) {
+                return "Range %s cannot be parsed back: %s".formatted(vers, e.getMessage());
+            }
+        }
+
+        for (int i = 0; i + 1 < versList.size(); i++) {
+            Vers current = versList.get(i);
+            Vers next = versList.get(i + 1);
+
+            Constraint upperBound = current.constraints().getLast();
+            Constraint lowerBound = next.constraints().getFirst();
+            if (upperBound.version() == null || lowerBound.version() == null) {
+                continue;
+            }
+
+            int comparison = upperBound.version().compareTo(lowerBound.version());
+            boolean touching = comparison == 0
+                    && upperBound.comparator() == Comparator.LESS_THAN_OR_EQUAL
+                    && lowerBound.comparator() == Comparator.GREATER_THAN_OR_EQUAL;
+            if (comparison > 0 || touching) {
+                return "Ranges %s and %s are not ascending and disjoint".formatted(current, next);
+            }
+        }
+
+        return null;
+    }
+
+    private static void writeResults(ObjectMapper objectMapper, String ecosystem, String suffix, ArrayNode results)
+            throws Exception {
+        try (final var outputStream =
+                Files.newOutputStream(Paths.get("target/results/osv-%s%s.json".formatted(ecosystem, suffix)))) {
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(outputStream, results);
+        }
     }
 }

--- a/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
+++ b/versatile-core/src/test/java/io/github/nscuro/versatile/VersUtilsTest.java
@@ -23,15 +23,22 @@ import static io.github.nscuro.versatile.VersUtils.schemeFromOsvEcosystem;
 import static io.github.nscuro.versatile.VersUtils.versFromGhsaRange;
 import static io.github.nscuro.versatile.VersUtils.versFromNvdRange;
 import static io.github.nscuro.versatile.VersUtils.versFromOsvRange;
+import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_PYPI;
+import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.github.nscuro.versatile.spi.Version;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -53,91 +60,6 @@ class VersUtilsTest {
             })
     void testVersFromGhsaRange(final String ghsaRange, final String expectedVers) {
         assertThat(versFromGhsaRange("other", ghsaRange)).hasToString(expectedVers);
-    }
-
-    private static Stream<Arguments> testVersFromOsvRangeArguments() {
-        return Stream.of(
-                arguments(List.of(Map.entry("introduced", "1.2.3")), null, "vers:other/>=1.2.3"),
-                arguments(
-                        List.of(Map.entry("introduced", "1.2.3"), Map.entry("fixed", "3.2.1")),
-                        null,
-                        "vers:other/>=1.2.3|<3.2.1"),
-                arguments(
-                        List.of(Map.entry("introduced", "1.2.3"), Map.entry("last_affected", "3.2.1")),
-                        null,
-                        "vers:other/>=1.2.3|<=3.2.1"),
-                arguments(
-                        List.of(Map.entry("last_affected", "3.2.1"), Map.entry("introduced", "1.2.3")),
-                        Map.of("foo", "bar"),
-                        "vers:other/>=1.2.3|<=3.2.1"),
-                arguments(
-                        List.of(Map.entry("introduced", "1.2.3"), Map.entry("limit", "3.2.1")),
-                        Map.of("last_known_affected_version_range", Map.of("foo", "bar")),
-                        "vers:other/>=1.2.3|<3.2.1"),
-                arguments(
-                        List.of(Map.entry("introduced", "4.5.6")),
-                        Map.of("last_known_affected_version_range", "<7.8.9"),
-                        "vers:other/>=4.5.6|<7.8.9"),
-                arguments(List.of(Map.entry("introduced", "0")), null, "vers:other/*"),
-                arguments(
-                        List.of(Map.entry("introduced", "0"), Map.entry("fixed", "3.2.1")), null, "vers:other/<3.2.1"),
-                arguments(
-                        List.of(Map.entry("introduced", "0"), Map.entry("last_affected", "3.2.1")),
-                        null,
-                        "vers:other/<=3.2.1"),
-                arguments(
-                        List.of(Map.entry("introduced", "0")),
-                        Map.of("last_known_affected_version_range", "<7.8.9"),
-                        "vers:other/<7.8.9"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("testVersFromOsvRangeArguments")
-    void testVersFromOsvRange(
-            final List<Map.Entry<String, String>> events,
-            final Map<String, Object> databaseSpecific,
-            final String expectedVers) {
-        assertThat(versFromOsvRange("ecosystem", "other", events, databaseSpecific))
-                .hasToString(expectedVers);
-    }
-
-    @Test
-    void testVersFromOsvRangeWithGoPseudoVersion() {
-        final Vers vers = versFromOsvRange(
-                "SEMVER",
-                "Go",
-                List.of(Map.entry("introduced", "0"), Map.entry("fixed", "0.0.0-20220412211240-33da011f77ad")),
-                null);
-
-        assertThat(vers).hasToString("vers:golang/<0.0.0-20220412211240-33da011f77ad");
-        assertThat(vers.contains("v0.47.0")).isFalse();
-        assertThat(vers.contains("v0.0.0-20220227234510-4e6760a101f9")).isTrue();
-    }
-
-    @Test
-    void testVersFromOsvRangeWithSuffixedEcosystem() {
-        final List<Map.Entry<String, String>> events =
-                List.of(Map.entry("introduced", "0"), Map.entry("fixed", "1.35.0"));
-
-        assertThat(versFromOsvRange("ecosystem", "Packagist:https://packages.drupal.org/8", events, null))
-                .hasToString("vers:composer/<1.35.0.0");
-        assertThat(versFromOsvRange("ecosystem", "VSCode:https://open-vsx.org", events, null))
-                .hasToString("vers:vscode/<1.35.0");
-        assertThat(versFromOsvRange("ecosystem", "TuxCare:Ubuntu:16.04", events, null))
-                .hasToString("vers:deb/<1.35.0");
-    }
-
-    @Test
-    void testVersFromOsvRangeWithInvalidRangeType() {
-        final List<Map.Entry<String, String>> events = List.of(Map.entry("introduced", "0"));
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> versFromOsvRange(null, "other", events, null));
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> versFromOsvRange("", "other", events, null));
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> versFromOsvRange("git", "other", events, null));
-        assertThatNoException().isThrownBy(() -> versFromOsvRange("ecosystem", "other", events, null));
-        assertThatNoException().isThrownBy(() -> versFromOsvRange("semver", "other", events, null));
     }
 
     @ParameterizedTest
@@ -265,6 +187,363 @@ class VersUtilsTest {
             assertThat(optionalVers).isNotPresent();
         } else {
             assertThat(optionalVers).map(Vers::toString).contains(expectedVers);
+        }
+    }
+
+    @Nested
+    class VersFromOsvRangeTest {
+
+        private static Stream<Arguments> versFromOsvRangeArguments() {
+            return Stream.of(
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0"),
+                                    Map.entry("fixed", "1.11.27"),
+                                    Map.entry("introduced", "2.2"),
+                                    Map.entry("fixed", "2.2.9")),
+                            List.of("vers:pypi/<1.11.27", "vers:pypi/>=2.2|<2.2.9")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "1"),
+                                    Map.entry("fixed", "2"),
+                                    Map.entry("introduced", "3"),
+                                    Map.entry("fixed", "4")),
+                            List.of("vers:pypi/>=1|<2", "vers:pypi/>=3|<4")),
+                    arguments(
+                            List.of(
+                                    Map.entry("fixed", "2"),
+                                    Map.entry("introduced", "3"),
+                                    Map.entry("introduced", "4"),
+                                    Map.entry("fixed", "5")),
+                            List.of("vers:pypi/>=3|<5")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0"),
+                                    Map.entry("last_affected", "1.2.1"),
+                                    Map.entry("last_affected", "1.2.0")),
+                            List.of("vers:pypi/<=1.2.0")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "2.0"),
+                                    Map.entry("introduced", "1.0"),
+                                    Map.entry("fixed", "2.5")),
+                            List.of("vers:pypi/>=1.0|<2.5")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "5.0.0"),
+                                    Map.entry("fixed", "5.0.12"),
+                                    Map.entry("introduced", "6.2.0"),
+                                    Map.entry("fixed", "6.2.2"),
+                                    Map.entry("fixed", "6.2.6")),
+                            List.of("vers:pypi/>=5.0.0|<5.0.12", "vers:pypi/>=6.2.0|<6.2.2")),
+                    arguments(
+                            List.of(Map.entry("introduced", "1.0.0"), Map.entry("limit", "*")),
+                            List.of("vers:pypi/>=1.0.0")),
+                    arguments(
+                            List.of(Map.entry("introduced", "0"), Map.entry("limit", "*"), Map.entry("limit", "5")),
+                            List.of("vers:pypi/*")),
+                    arguments(
+                            List.of(Map.entry("introduced", "1.0.0"), Map.entry("limit", "5"), Map.entry("limit", "*")),
+                            List.of("vers:pypi/>=1.0.0")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0"),
+                                    Map.entry("introduced", "1.0"),
+                                    Map.entry("fixed", "1.1")),
+                            List.of("vers:pypi/<1.1")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0"),
+                                    Map.entry("limit", "5"),
+                                    Map.entry("introduced", "6"),
+                                    Map.entry("fixed", "7")),
+                            List.of("vers:pypi/<5")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0"),
+                                    Map.entry("fixed", "1.0.0"),
+                                    Map.entry("introduced", "2.0.0"),
+                                    Map.entry("limit", "3.0.0")),
+                            List.of("vers:pypi/<1.0.0", "vers:pypi/>=2.0.0|<3.0.0")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "1.0.0"),
+                                    Map.entry("fixed", "1.2.0"),
+                                    Map.entry("introduced", "2.0.0")),
+                            List.of("vers:pypi/>=1.0.0|<1.2.0", "vers:pypi/>=2.0.0")),
+                    arguments(List.of(Map.entry("introduced", "0")), List.of("vers:pypi/*")),
+                    arguments(List.of(Map.entry("fixed", "1.2.0")), List.of()),
+                    arguments(List.of(Map.entry("introduced", "3"), Map.entry("fixed", "3")), List.of()),
+                    arguments(List.of(Map.entry("introduced", "3"), Map.entry("limit", "3")), List.of()),
+                    arguments(
+                            List.of(Map.entry("introduced", "3"), Map.entry("last_affected", "3")),
+                            List.of("vers:pypi/>=3|<=3")),
+                    arguments(
+                            List.of(
+                                    Map.entry("introduced", "0.23.0"),
+                                    Map.entry("fixed", "0.23.0"),
+                                    Map.entry("introduced", "0.23.13"),
+                                    Map.entry("fixed", "0.23.18")),
+                            List.of("vers:pypi/>=0.23.13|<0.23.18")));
+        }
+
+        @ParameterizedTest
+        @MethodSource("versFromOsvRangeArguments")
+        void versFromOsvRangeShouldReturnOneRangePerAffectedInterval(
+                final List<Map.Entry<String, String>> events, final List<String> expectedVers) {
+            assertThat(versFromOsvRange("ECOSYSTEM", "PyPI", events, null))
+                    .extracting(Vers::toString)
+                    .containsExactlyElementsOf(expectedVers);
+        }
+
+        @Test
+        void versFromOsvRangeShouldIgnoreDebianUnfixedSentinels() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "Debian:12",
+                            List.of(Map.entry("introduced", "0"), Map.entry("fixed", "<unfixed>")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:deb/*");
+        }
+
+        @Test
+        void versFromOsvRangeShouldRetainGoPseudoVersionUpperBound() {
+            final List<Vers> versList = versFromOsvRange(
+                    "SEMVER",
+                    "Go",
+                    List.of(Map.entry("introduced", "0"), Map.entry("fixed", "0.0.0-20220412211240-33da011f77ad")),
+                    null);
+
+            assertThat(versList)
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:golang/<0.0.0-20220412211240-33da011f77ad");
+            assertThat(versList.getFirst().contains("v0.47.0")).isFalse();
+            assertThat(versList.getFirst().contains("v0.0.0-20220227234510-4e6760a101f9"))
+                    .isTrue();
+        }
+
+        @Test
+        void versFromOsvRangeShouldMapSuffixedEcosystemToScheme() {
+            List<Map.Entry<String, String>> events =
+                    List.of(Map.entry("introduced", "0"), Map.entry("fixed", "1.35.0"));
+
+            assertThat(versFromOsvRange("ecosystem", "Packagist:https://packages.drupal.org/8", events, null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:composer/<1.35.0.0");
+            assertThat(versFromOsvRange("ecosystem", "VSCode:https://open-vsx.org", events, null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:vscode/<1.35.0");
+            assertThat(versFromOsvRange("ecosystem", "TuxCare:Ubuntu:16.04", events, null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:deb/<1.35.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldApplyLastKnownAffectedVersionRangeToOpenLastInterval() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(
+                                    Map.entry("introduced", "1.0.0"),
+                                    Map.entry("fixed", "1.2.0"),
+                                    Map.entry("introduced", "2.0.0")),
+                            Map.of("last_known_affected_version_range", "<= 2.5.0")))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:pypi/>=1.0.0|<1.2.0", "vers:pypi/>=2.0.0|<=2.5.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldIgnoreLastKnownAffectedVersionRangeWhenLastIntervalIsBounded() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(Map.entry("introduced", "1.0.0"), Map.entry("fixed", "1.2.0")),
+                            Map.of("last_known_affected_version_range", "<2.5.0")))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:pypi/>=1.0.0|<1.2.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldFallBackToGenericSchemeForInvalidVersions() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(Map.entry("introduced", "0"), Map.entry("fixed", "4.6.0.stable11")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:generic/<4.6.0.stable11");
+        }
+
+        @Test
+        void versFromOsvRangeShouldRetainIntervalsWhenFallingBackToGenericScheme() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(
+                                    Map.entry("introduced", "1.0"),
+                                    Map.entry("fixed", "2.0.x"),
+                                    Map.entry("introduced", "3.0"),
+                                    Map.entry("fixed", "4.0")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:generic/>=1.0|<2.0.x", "vers:generic/>=3.0|<4.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldAcceptAnyVersionUnderGenericScheme() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "generic",
+                            List.of(Map.entry("introduced", "0"), Map.entry("fixed", "2.0.x")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:generic/<2.0.x");
+        }
+
+        @Test
+        void versFromOsvRangeShouldIgnoreUnfixedSentinelsRegardlessOfScheme() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(Map.entry("introduced", "1.0"), Map.entry("fixed", "<unfixed>")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:pypi/>=1.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldThrowForInvalidRangeType() {
+            final List<Map.Entry<String, String>> events = List.of(Map.entry("introduced", "0"));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> versFromOsvRange(null, "other", events, null));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> versFromOsvRange("", "other", events, null));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> versFromOsvRange("git", "other", events, null));
+            assertThatNoException().isThrownBy(() -> versFromOsvRange("ecosystem", "other", events, null));
+            assertThatNoException().isThrownBy(() -> versFromOsvRange("semver", "other", events, null));
+        }
+
+        @Test
+        void versFromOsvRangeShouldTreatOnlyExactWildcardLimitAsInfinity() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(Map.entry("introduced", "0"), Map.entry("limit", "1.*")),
+                            null))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:generic/<1.%2A");
+        }
+
+        @Test
+        void versFromOsvRangeShouldIgnoreNonStringLastKnownAffectedVersionRange() {
+            assertThat(versFromOsvRange(
+                            "ECOSYSTEM",
+                            "PyPI",
+                            List.of(Map.entry("introduced", "1.0.0")),
+                            Map.of("last_known_affected_version_range", Map.of("foo", "bar"))))
+                    .extracting(Vers::toString)
+                    .containsExactly("vers:pypi/>=1.0.0");
+        }
+
+        @Test
+        void versFromOsvRangeShouldThrowForInvalidEvent() {
+            final List<Map.Entry<String, String>> events =
+                    List.of(Map.entry("introduced", "0"), Map.entry("foo", "1.2.3"));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> versFromOsvRange("ecosystem", "other", events, null))
+                    .withMessage("Invalid event \"foo\" at position 1");
+        }
+
+        /**
+         * Cross-checks the conversion against a transcription of OSV's evaluation algorithm,
+         * over randomly generated ranges.
+         *
+         * @see <a href="https://ossf.github.io/osv-schema/#evaluation">OSV evaluation algorithm</a>
+         */
+        @Nested
+        class OsvEvaluationCrossCheck {
+
+            private static final List<String> VERSIONS = List.of("0", "1", "2", "3", "4", "5", "6");
+            private static final List<String> EVENT_KEYS = List.of("introduced", "fixed", "last_affected", "limit");
+
+            @Test
+            void versFromOsvRangeShouldMatchOsvEvaluationAlgorithm() {
+                final var random = new Random(666L);
+
+                for (int i = 0; i < 2_000; i++) {
+                    final List<Map.Entry<String, String>> events = randomEvents(random);
+                    final List<Vers> versList =
+                            versFromOsvRange("ECOSYSTEM", "PyPI", events, /* databaseSpecific */ null);
+
+                    for (final String version : VERSIONS) {
+                        final boolean expected = includedInRange(version, events);
+
+                        assertThat(versList.stream().anyMatch(vers -> vers.contains(version)))
+                                .withFailMessage(
+                                        "events=%s, version=%s, ranges=%s, expected=%s",
+                                        events, version, versList, expected)
+                                .isEqualTo(expected);
+                    }
+                }
+            }
+
+            private static List<Map.Entry<String, String>> randomEvents(Random random) {
+                final var versions = new ArrayList<>(VERSIONS);
+                Collections.shuffle(versions, random);
+
+                final var events = new ArrayList<Map.Entry<String, String>>();
+                for (final String version : versions.subList(0, 1 + random.nextInt(VERSIONS.size()))) {
+                    events.add(Map.entry(EVENT_KEYS.get(random.nextInt(EVENT_KEYS.size())), version));
+                }
+
+                return events;
+            }
+
+            private static boolean includedInRange(String v, List<Map.Entry<String, String>> range) {
+                if (beforeLimits(v, range)) {
+                    final Version version = VersionFactory.forScheme(SCHEME_PYPI, v);
+                    final var sortedEvents = new ArrayList<>(range);
+                    sortedEvents.sort(comparing((Map.Entry<String, String> event) ->
+                            VersionFactory.forScheme(SCHEME_PYPI, event.getValue())));
+
+                    boolean vulnerable = false;
+                    for (final Map.Entry<String, String> event : sortedEvents) {
+                        final Version eventVersion = VersionFactory.forScheme(SCHEME_PYPI, event.getValue());
+
+                        if ("introduced".equals(event.getKey()) && version.compareTo(eventVersion) >= 0) {
+                            vulnerable = true;
+                        } else if ("fixed".equals(event.getKey()) && version.compareTo(eventVersion) >= 0) {
+                            vulnerable = false;
+                        } else if ("last_affected".equals(event.getKey()) && version.compareTo(eventVersion) > 0) {
+                            vulnerable = false;
+                        }
+                    }
+
+                    return vulnerable;
+                }
+
+                return false;
+            }
+
+            private static boolean beforeLimits(String v, List<Map.Entry<String, String>> range) {
+                final Version version = VersionFactory.forScheme(SCHEME_PYPI, v);
+                boolean hasLimit = false;
+
+                for (final Map.Entry<String, String> event : range) {
+                    if (!"limit".equals(event.getKey())) {
+                        continue;
+                    }
+                    hasLimit = true;
+                    if (version.compareTo(VersionFactory.forScheme(SCHEME_PYPI, event.getValue())) < 0) {
+                        return true;
+                    }
+                }
+
+                // No limit events means an implicit { "limit": "*" }.
+                return !hasLimit;
+            }
         }
     }
 }


### PR DESCRIPTION
Corrects a few issues the previous implementation got wrong:

* The OSV evaluation algo wants events to be sorted by version. Correct ordering in advisories is recommended by the spec but not guaranteed. We now sort instead of relying on loose recommendations.
* OSV range events are split into intervals *before* being parsed as vers. OSV's specific range event semantics do not align with how `Vers#simplify` and `Vers#split` work.

> [!WARNING]
> This is a breaking change for `VersUtils#versFromOsvRange`. The method now returns `List<Vers>` with pre-split intervals instead of a single `Vers`.