### PR TITLE
vers spec 1.2.0 conformance

### DIFF
--- a/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
+++ b/versatile-conformance/src/test/java/io/github/nscuro/versatile/conformance/VersConformanceTest.java
@@ -198,9 +198,9 @@ class VersConformanceTest {
         assertThat(expectedOutput).isNotNull();
 
         final var vers = Vers.parse(input);
-        assertThat(vers.scheme()).as(versTest.getDescription()).isEqualTo(expectedOutput.get("scheme"));
+        assertThat(vers.scheme()).as(versTest.getDescription()).isEqualTo(expectedOutput.get("type"));
 
-        final var expectedConstraints = (List<List<String>>) expectedOutput.get("version_constraints");
+        final var expectedConstraints = (List<List<String>>) expectedOutput.get("constraints");
         final List<List<String>> actualConstraints = vers.constraints().stream()
                 .map(constraint -> List.of(
                         constraint.comparator().operator(), constraint.version().toString()))

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/Constraint.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/Constraint.java
@@ -46,6 +46,11 @@ public class Constraint implements Comparable<Constraint> {
     }
 
     static Constraint parse(String scheme, String constraintStr, boolean strict) {
+        if (strict && constraintStr.startsWith("=")) {
+            throw new VersException("equality comparator is implicit and must not be stated explicitly in \"%s\""
+                    .formatted(constraintStr));
+        }
+
         final Comparator comparator;
         if (constraintStr.startsWith("<=")) {
             comparator = Comparator.LESS_THAN_OR_EQUAL;

--- a/versatile-core/src/main/java/io/github/nscuro/versatile/PercentEncoding.java
+++ b/versatile-core/src/main/java/io/github/nscuro/versatile/PercentEncoding.java
@@ -73,6 +73,11 @@ final class PercentEncoding {
             }
 
             final int decoded = hi << 4 | lo;
+            if (strict && decoded != ' ' && Character.isWhitespace(decoded)) {
+                throw new VersException("""
+                        Value "%s" contains percent-encoded whitespace at index %d, \
+                        but only SPACE (%%20) is permitted""".formatted(value, i));
+            }
             if (strict && !mustEncode(decoded)) {
                 throw new VersException("""
                         Percent-encoded triplet at index %d of value "%s" is non-canonical, \


### PR DESCRIPTION
Updates vers-spec to 1.2.0 and fixes issues identified by the conformance test suite:

* Strict parsing does not allow explicit `=` comparators.
* Strict parsing does not allow percent-encoded whitespace that is not space.